### PR TITLE
Feature/add scan merger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# orange_ros2 v0.5.4 [![](https://img.shields.io/badge/ROS2%20Humble-stable-green?style=flat-square&logo=ros)](https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2)
+# orange_ros2 v0.5.5 [![](https://img.shields.io/badge/ROS2%20Humble-stable-green?style=flat-square&logo=ros)](https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2)
 This repository contains [ROS2](https://docs.ros.org/en/humble/index.html) version of Hosei orange, which has competed in the [Tsukuba Challenge](https://tsukubachallenge.connpass.com/) and [IGVC](http://www.igvc.org/). It supports several Gazebo world, SLAM methods and provides navigation feature.
 
 <img src="https://user-images.githubusercontent.com/84959376/215265266-5b24f066-24a1-4a5a-ab69-3daf754b6bd4.png" width="400px">
@@ -70,7 +70,8 @@ $ ros2 launch orange_navigation navigation2.launch.xml slam_method:={SLAM_METHOD
 ## Sample dataset
 You can download the ros2 bag obtained from orange_world.
 
-- [ros2bag_orange_world.zip](https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2/files/10527314/ros2bag_orange_world.zip)
+- [ros2bag_orange_world.zip](https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2/files/11183516/ros2bag_orange_world.zip)
+
 
 ## Reference
 - slam_toolbox : https://github.com/SteveMacenski/slam_toolbox

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# orange_ros2 v0.5.0 [![](https://img.shields.io/badge/ROS2%20Humble-stable-green?style=flat-square&logo=ros)](https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2)
+# orange_ros2 v0.5.1 [![](https://img.shields.io/badge/ROS2%20Humble-stable-green?style=flat-square&logo=ros)](https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2)
 This repository contains [ROS2](https://docs.ros.org/en/humble/index.html) version of Hosei orange, which has competed in the [Tsukuba Challenge](https://tsukubachallenge.connpass.com/) and [IGVC](http://www.igvc.org/). It supports several Gazebo world, SLAM methods and provides navigation feature.
 
 <img src="https://user-images.githubusercontent.com/84959376/215265266-5b24f066-24a1-4a5a-ab69-3daf754b6bd4.png" width="400px">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# orange_ros2 v0.4.1 [![](https://img.shields.io/badge/ROS2%20Humble-stable-green?style=flat-square&logo=ros)](https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2)
+# orange_ros2 v0.5.0 [![](https://img.shields.io/badge/ROS2%20Humble-stable-green?style=flat-square&logo=ros)](https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2)
 This repository contains [ROS2](https://docs.ros.org/en/humble/index.html) version of Hosei orange, which has competed in the [Tsukuba Challenge](https://tsukubachallenge.connpass.com/) and [IGVC](http://www.igvc.org/). It supports several Gazebo world, SLAM methods and provides navigation feature.
 
 <img src="https://user-images.githubusercontent.com/84959376/215265266-5b24f066-24a1-4a5a-ab69-3daf754b6bd4.png" width="400px">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# orange_ros2 v0.5.1 [![](https://img.shields.io/badge/ROS2%20Humble-stable-green?style=flat-square&logo=ros)](https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2)
+# orange_ros2 v0.5.2 [![](https://img.shields.io/badge/ROS2%20Humble-stable-green?style=flat-square&logo=ros)](https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2)
 This repository contains [ROS2](https://docs.ros.org/en/humble/index.html) version of Hosei orange, which has competed in the [Tsukuba Challenge](https://tsukubachallenge.connpass.com/) and [IGVC](http://www.igvc.org/). It supports several Gazebo world, SLAM methods and provides navigation feature.
 
 <img src="https://user-images.githubusercontent.com/84959376/215265266-5b24f066-24a1-4a5a-ab69-3daf754b6bd4.png" width="400px">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# orange_ros2 v0.5.3 [![](https://img.shields.io/badge/ROS2%20Humble-stable-green?style=flat-square&logo=ros)](https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2)
+# orange_ros2 v0.5.4 [![](https://img.shields.io/badge/ROS2%20Humble-stable-green?style=flat-square&logo=ros)](https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2)
 This repository contains [ROS2](https://docs.ros.org/en/humble/index.html) version of Hosei orange, which has competed in the [Tsukuba Challenge](https://tsukubachallenge.connpass.com/) and [IGVC](http://www.igvc.org/). It supports several Gazebo world, SLAM methods and provides navigation feature.
 
 <img src="https://user-images.githubusercontent.com/84959376/215265266-5b24f066-24a1-4a5a-ab69-3daf754b6bd4.png" width="400px">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# orange_ros2 v0.5.2 [![](https://img.shields.io/badge/ROS2%20Humble-stable-green?style=flat-square&logo=ros)](https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2)
+# orange_ros2 v0.5.3 [![](https://img.shields.io/badge/ROS2%20Humble-stable-green?style=flat-square&logo=ros)](https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2)
 This repository contains [ROS2](https://docs.ros.org/en/humble/index.html) version of Hosei orange, which has competed in the [Tsukuba Challenge](https://tsukubachallenge.connpass.com/) and [IGVC](http://www.igvc.org/). It supports several Gazebo world, SLAM methods and provides navigation feature.
 
 <img src="https://user-images.githubusercontent.com/84959376/215265266-5b24f066-24a1-4a5a-ab69-3daf754b6bd4.png" width="400px">

--- a/orange_bringup/package.xml
+++ b/orange_bringup/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>orange_bringup</name>
-  <version>0.5.0</version>
+  <version>0.0.0</version>
   <description>ROS2 launch scripts for starting the orange robot</description>
   <maintainer email="shunki.shibuya.5v@stu.hosei.ac.jp">Shibuya</maintainer>
   <maintainer email="koki.kubota.8p@stu.hosei.ac.jp">Kubota</maintainer>

--- a/orange_bringup/package.xml
+++ b/orange_bringup/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>orange_bringup</name>
-  <version>0.4.1</version>
+  <version>0.5.0</version>
   <description>ROS2 launch scripts for starting the orange robot</description>
   <maintainer email="shunki.shibuya.5v@stu.hosei.ac.jp">Shibuya</maintainer>
   <maintainer email="koki.kubota.8p@stu.hosei.ac.jp">Kubota</maintainer>

--- a/orange_description/package.xml
+++ b/orange_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>orange_description</name>
-  <version>0.4.1</version>
+  <version>0.5.0</version>
   <description>3D models of the orange robot for ROS2 simulation and visualization</description>
   <maintainer email="shunki.shibuya.5v@stu.hosei.ac.jp">Shibuya</maintainer>
   <maintainer email="koki.kubota.8p@stu.hosei.ac.jp">Kubota</maintainer>

--- a/orange_description/package.xml
+++ b/orange_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>orange_description</name>
-  <version>0.5.0</version>
+  <version>0.0.0</version>
   <description>3D models of the orange robot for ROS2 simulation and visualization</description>
   <maintainer email="shunki.shibuya.5v@stu.hosei.ac.jp">Shibuya</maintainer>
   <maintainer email="koki.kubota.8p@stu.hosei.ac.jp">Kubota</maintainer>

--- a/orange_description/rviz2/cartographer.rviz
+++ b/orange_description/rviz2/cartographer.rviz
@@ -151,23 +151,24 @@ Visualization Manager:
       Show Names: false
       Tree:
         map:
-          odom:
-            base_footprint:
-              base_link:
-                hokuyo_link:
-                  {}
-                imu_link:
-                  {}
-                left_caster_link:
-                  {}
-                left_wheel:
-                  {}
-                right_caster_link:
-                  {}
-                right_wheel:
-                  {}
-                velodyne_link:
-                  {}
+          {}
+        odom:
+          base_footprint:
+            base_link:
+              hokuyo_link:
+                {}
+              imu_link:
+                {}
+              left_caster_link:
+                {}
+              left_wheel:
+                {}
+              right_caster_link:
+                {}
+              right_wheel:
+                {}
+              velodyne_link:
+                {}
       Update Interval: 0
       Value: true
     - Alpha: 1
@@ -201,6 +202,40 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Reliable
         Value: /velodyne_points
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/LaserScan
+      Color: 85; 0; 255
+      Color Transformer: FlatColor
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: merged_scan
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 2
+      Size (m): 0.009999999776482582
+      Style: Points
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Best Effort
+        Value: /merged_scan
       Use Fixed Frame: true
       Use rainbow: true
       Value: false
@@ -250,7 +285,7 @@ Visualization Manager:
       Color: 255; 255; 0
       Color Transformer: FlatColor
       Decay Time: 0
-      Enabled: false
+      Enabled: true
       Invert Rainbow: false
       Max Color: 255; 255; 255
       Max Intensity: 0
@@ -271,7 +306,7 @@ Visualization Manager:
         Value: /hokuyo_scan
       Use Fixed Frame: true
       Use rainbow: true
-      Value: false
+      Value: true
     - Angle Tolerance: 0.10000000149011612
       Class: rviz_default_plugins/Odometry
       Covariance:

--- a/orange_description/rviz2/navigation2.rviz
+++ b/orange_description/rviz2/navigation2.rviz
@@ -188,6 +188,40 @@ Visualization Manager:
       Axis: Z
       Channel Name: intensity
       Class: rviz_default_plugins/LaserScan
+      Color: 85; 0; 255
+      Color Transformer: FlatColor
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: merged_scan
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Points
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Best Effort
+        Value: /merged_scan
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/LaserScan
       Color: 255; 255; 0
       Color Transformer: FlatColor
       Decay Time: 0

--- a/orange_description/rviz2/orange_robot.rviz
+++ b/orange_description/rviz2/orange_robot.rviz
@@ -25,7 +25,7 @@ Panels:
     Experimental: false
     Name: Time
     SyncMode: 0
-    SyncSource: ""
+    SyncSource: velodyne_scan
 Visualization Manager:
   Class: ""
   Displays:
@@ -148,24 +148,23 @@ Visualization Manager:
       Show Axes: true
       Show Names: false
       Tree:
-        base_footprint:
-          base_link:
-            hokuyo_link:
-              {}
-            imu_link:
-              {}
-            left_caster_link:
-              {}
-            left_wheel:
-              {}
-            right_caster_link:
-              {}
-            right_wheel:
-              {}
-            velodyne_link:
-              {}
         odom:
-          {}
+          base_footprint:
+            base_link:
+              hokuyo_link:
+                {}
+              imu_link:
+                {}
+              left_caster_link:
+                {}
+              left_wheel:
+                {}
+              right_caster_link:
+                {}
+              right_wheel:
+                {}
+              velodyne_link:
+                {}
       Update Interval: 0
       Value: true
     - Alpha: 1
@@ -199,6 +198,40 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Reliable
         Value: /velodyne_points
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/LaserScan
+      Color: 85; 0; 255
+      Color Transformer: FlatColor
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: merged_scan
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 2
+      Size (m): 0.009999999776482582
+      Style: Points
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Best Effort
+        Value: /merged_scan
       Use Fixed Frame: true
       Use rainbow: true
       Value: false

--- a/orange_description/rviz2/slam_toolbox.rviz
+++ b/orange_description/rviz2/slam_toolbox.rviz
@@ -213,10 +213,44 @@ Visualization Manager:
       Axis: Z
       Channel Name: intensity
       Class: rviz_default_plugins/LaserScan
-      Color: 85; 255; 127
+      Color: 85; 0; 255
       Color Transformer: FlatColor
       Decay Time: 0
       Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: merged_scan
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 2
+      Size (m): 0.009999999776482582
+      Style: Points
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Best Effort
+        Value: /merged_scan
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/LaserScan
+      Color: 85; 255; 127
+      Color Transformer: FlatColor
+      Decay Time: 0
+      Enabled: false
       Invert Rainbow: false
       Max Color: 255; 255; 255
       Max Intensity: 4096
@@ -237,7 +271,7 @@ Visualization Manager:
         Value: /velodyne_scan
       Use Fixed Frame: true
       Use rainbow: true
-      Value: true
+      Value: false
     - Alpha: 1
       Autocompute Intensity Bounds: true
       Autocompute Value Bounds:

--- a/orange_gazebo/launch/empty_world.launch.xml
+++ b/orange_gazebo/launch/empty_world.launch.xml
@@ -2,11 +2,15 @@
 
   <arg name="use_sim_time" default="true" />
 
-  <arg name="cloud_in" default="/velodyne_points" />
-  <arg name="scan_out" default="/velodyne_scan" />
-  <arg name="odom_in" default="/odom" />
-  <arg name="imu_in" default="/imu" />
-  <arg name="fusion_odom_out" default="/fusion/odom" />
+  <arg name="velodyne_frame" default="velodyne_link" />
+  <arg name="hokuyo_scan_topic" default="/hokuyo_scan" />
+  <arg name="velodyne_scan_topic" default="/velodyne_scan" />
+  <arg name="velodyne_points_topic" default="/velodyne_points" />
+  <arg name="merged_cloud_topic" default="/merged_cloud" />
+  <arg name="merged_scan_topic" default="/merged_scan" />
+  <arg name="odom_topic" default="/odom" />
+  <arg name="imu_topic" default="/imu" />
+  <arg name="fusion_odom_topic" default="/fusion/odom" />
 
   <arg name="world_file_path" default="$(find-pkg-share gazebo_ros)/worlds/empty.world" />
   <arg name="xacro_file_path" default="$(find-pkg-share orange_description)/xacro/orange_robot.xacro" />
@@ -14,16 +18,26 @@
   <!-- pointcloud_to_laserscan -->
   <include file="$(find-pkg-share orange_sensor_tools)/launch/pointcloud_to_laserscan.launch.xml">
     <arg name="use_sim_time" value="$(var use_sim_time)" />
-    <arg name="cloud_in" value="$(var cloud_in)" />
-    <arg name="scan_out" value="$(var scan_out)" />
+    <arg name="cloud_in" value="$(var velodyne_points_topic)" />
+    <arg name="scan_out" value="$(var velodyne_scan_topic)" />
+  </include>
+
+  <!-- laserscan_multi_merger -->
+  <include file="$(find-pkg-share orange_sensor_tools)/launch/laserscan_multi_merger.launch.xml">
+    <arg name="use_sim_time" value="$(var use_sim_time)" />
+    <arg name="delete_intensity" value="true" />
+    <arg name="destination_frame" value="$(var velodyne_frame)" />
+    <arg name="cloud_destination_topic" value="$(var merged_cloud_topic)" />
+    <arg name="scan_destination_topic" value="$(var merged_scan_topic)" />
+    <arg name="laserscan_topics" value="$(var hokuyo_scan_topic) $(var velodyne_scan_topic)" />
   </include>
 
   <!-- robot_localization -->
   <include file="$(find-pkg-share orange_sensor_tools)/launch/localization.launch.xml">
     <arg name="use_sim_time" value="$(var use_sim_time)" />
-    <arg name="odom_in" value="$(var odom_in)" />
-    <arg name="imu_in" value="$(var imu_in)" />
-    <arg name="fusion_odom_out" value="$(var fusion_odom_out)" />
+    <arg name="odom_in" value="$(var odom_topic)" />
+    <arg name="imu_in" value="$(var imu_topic)" />
+    <arg name="fusion_odom_out" value="$(var fusion_odom_topic)" />
   </include>
 
   <!-- gzserver -->

--- a/orange_gazebo/launch/orange_igvc.launch.xml
+++ b/orange_gazebo/launch/orange_igvc.launch.xml
@@ -2,11 +2,15 @@
 
   <arg name="use_sim_time" default="true" />
 
-  <arg name="cloud_in" default="/velodyne_points" />
-  <arg name="scan_out" default="/velodyne_scan" />
-  <arg name="odom_in" default="/odom" />
-  <arg name="imu_in" default="/imu" />
-  <arg name="fusion_odom_out" default="/fusion/odom" />
+  <arg name="velodyne_frame" default="velodyne_link" />
+  <arg name="hokuyo_scan_topic" default="/hokuyo_scan" />
+  <arg name="velodyne_scan_topic" default="/velodyne_scan" />
+  <arg name="velodyne_points_topic" default="/velodyne_points" />
+  <arg name="merged_cloud_topic" default="/merged_cloud" />
+  <arg name="merged_scan_topic" default="/merged_scan" />
+  <arg name="odom_topic" default="/odom" />
+  <arg name="imu_topic" default="/imu" />
+  <arg name="fusion_odom_topic" default="/fusion/odom" />
 
   <arg name="world_file_path" default="$(find-pkg-share orange_gazebo)/worlds/orange_igvc.world" />
   <arg name="xacro_file_path" default="$(find-pkg-share orange_description)/xacro/orange_robot.xacro" />
@@ -14,16 +18,26 @@
   <!-- pointcloud_to_laserscan -->
   <include file="$(find-pkg-share orange_sensor_tools)/launch/pointcloud_to_laserscan.launch.xml">
     <arg name="use_sim_time" value="$(var use_sim_time)" />
-    <arg name="cloud_in" value="$(var cloud_in)" />
-    <arg name="scan_out" value="$(var scan_out)" />
+    <arg name="cloud_in" value="$(var velodyne_points_topic)" />
+    <arg name="scan_out" value="$(var velodyne_scan_topic)" />
+  </include>
+
+  <!-- laserscan_multi_merger -->
+  <include file="$(find-pkg-share orange_sensor_tools)/launch/laserscan_multi_merger.launch.xml">
+    <arg name="use_sim_time" value="$(var use_sim_time)" />
+    <arg name="delete_intensity" value="true" />
+    <arg name="destination_frame" value="$(var velodyne_frame)" />
+    <arg name="cloud_destination_topic" value="$(var merged_cloud_topic)" />
+    <arg name="scan_destination_topic" value="$(var merged_scan_topic)" />
+    <arg name="laserscan_topics" value="$(var hokuyo_scan_topic) $(var velodyne_scan_topic)" />
   </include>
 
   <!-- robot_localization -->
   <include file="$(find-pkg-share orange_sensor_tools)/launch/localization.launch.xml">
     <arg name="use_sim_time" value="$(var use_sim_time)" />
-    <arg name="odom_in" value="$(var odom_in)" />
-    <arg name="imu_in" value="$(var imu_in)" />
-    <arg name="fusion_odom_out" value="$(var fusion_odom_out)" />
+    <arg name="odom_in" value="$(var odom_topic)" />
+    <arg name="imu_in" value="$(var imu_topic)" />
+    <arg name="fusion_odom_out" value="$(var fusion_odom_topic)" />
   </include>
 
   <!-- gzserver -->

--- a/orange_gazebo/launch/orange_world.launch.xml
+++ b/orange_gazebo/launch/orange_world.launch.xml
@@ -2,11 +2,15 @@
 
   <arg name="use_sim_time" default="true" />
 
-  <arg name="cloud_in" default="/velodyne_points" />
-  <arg name="scan_out" default="/velodyne_scan" />
-  <arg name="odom_in" default="/odom" />
-  <arg name="imu_in" default="/imu" />
-  <arg name="fusion_odom_out" default="/fusion/odom" />
+  <arg name="velodyne_frame" default="velodyne_link" />
+  <arg name="hokuyo_scan_topic" default="/hokuyo_scan" />
+  <arg name="velodyne_scan_topic" default="/velodyne_scan" />
+  <arg name="velodyne_points_topic" default="/velodyne_points" />
+  <arg name="merged_cloud_topic" default="/merged_cloud" />
+  <arg name="merged_scan_topic" default="/merged_scan" />
+  <arg name="odom_topic" default="/odom" />
+  <arg name="imu_topic" default="/imu" />
+  <arg name="fusion_odom_topic" default="/fusion/odom" />
 
   <arg name="world_file_path" default="$(find-pkg-share orange_gazebo)/worlds/orange_world.world" />
   <arg name="xacro_file_path" default="$(find-pkg-share orange_description)/xacro/orange_robot.xacro" />
@@ -14,16 +18,26 @@
   <!-- pointcloud_to_laserscan -->
   <include file="$(find-pkg-share orange_sensor_tools)/launch/pointcloud_to_laserscan.launch.xml">
     <arg name="use_sim_time" value="$(var use_sim_time)" />
-    <arg name="cloud_in" value="$(var cloud_in)" />
-    <arg name="scan_out" value="$(var scan_out)" />
+    <arg name="cloud_in" value="$(var velodyne_points_topic)" />
+    <arg name="scan_out" value="$(var velodyne_scan_topic)" />
+  </include>
+
+  <!-- laserscan_multi_merger -->
+  <include file="$(find-pkg-share orange_sensor_tools)/launch/laserscan_multi_merger.launch.xml">
+    <arg name="use_sim_time" value="$(var use_sim_time)" />
+    <arg name="delete_intensity" value="true" />
+    <arg name="destination_frame" value="$(var velodyne_frame)" />
+    <arg name="cloud_destination_topic" value="$(var merged_cloud_topic)" />
+    <arg name="scan_destination_topic" value="$(var merged_scan_topic)" />
+    <arg name="laserscan_topics" value="$(var hokuyo_scan_topic) $(var velodyne_scan_topic)" />
   </include>
 
   <!-- robot_localization -->
   <include file="$(find-pkg-share orange_sensor_tools)/launch/localization.launch.xml">
     <arg name="use_sim_time" value="$(var use_sim_time)" />
-    <arg name="odom_in" value="$(var odom_in)" />
-    <arg name="imu_in" value="$(var imu_in)" />
-    <arg name="fusion_odom_out" value="$(var fusion_odom_out)" />
+    <arg name="odom_in" value="$(var odom_topic)" />
+    <arg name="imu_in" value="$(var imu_topic)" />
+    <arg name="fusion_odom_out" value="$(var fusion_odom_topic)" />
   </include>
 
   <!-- gzserver -->

--- a/orange_gazebo/package.xml
+++ b/orange_gazebo/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>orange_gazebo</name>
-  <version>0.5.0</version>
+  <version>0.0.0</version>
   <description>ROS2 gazebo simulation tools for the orange robot</description>
   <maintainer email="shunki.shibuya.5v@stu.hosei.ac.jp">Shibuya</maintainer>
   <maintainer email="koki.kubota.8p@stu.hosei.ac.jp">Kubota</maintainer>

--- a/orange_gazebo/package.xml
+++ b/orange_gazebo/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>orange_gazebo</name>
-  <version>0.4.1</version>
+  <version>0.5.0</version>
   <description>ROS2 gazebo simulation tools for the orange robot</description>
   <maintainer email="shunki.shibuya.5v@stu.hosei.ac.jp">Shibuya</maintainer>
   <maintainer email="koki.kubota.8p@stu.hosei.ac.jp">Kubota</maintainer>

--- a/orange_navigation/config/navigation2_params.yaml
+++ b/orange_navigation/config/navigation2_params.yaml
@@ -44,7 +44,7 @@ amcl:
     z_max: 0.05
     z_rand: 0.5
     z_short: 0.05
-    scan_topic: /velodyne_scan
+    scan_topic: /merged_scan
 
 amcl_map_client:
   ros__parameters:
@@ -203,7 +203,7 @@ local_costmap:
         enabled: True
         observation_sources: scan
         scan:
-          topic: /velodyne_scan
+          topic: /merged_scan
           max_obstacle_height: 2.5
           clearing: True
           marking: True
@@ -235,7 +235,7 @@ global_costmap:
         enabled: True
         observation_sources: scan
         scan:
-          topic: /velodyne_scan
+          topic: /merged_scan
           max_obstacle_height: 2.5
           clearing: True
           marking: True

--- a/orange_navigation/package.xml
+++ b/orange_navigation/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>orange_navigation</name>
-  <version>0.5.0</version>
+  <version>0.0.0</version>
   <description>ROS2 navigation for the orange robot</description>
   <maintainer email="shunki.shibuya.5v@stu.hosei.ac.jp">Shibuya</maintainer>
   <maintainer email="koki.kubota.8p@stu.hosei.ac.jp">Kubota</maintainer>

--- a/orange_navigation/package.xml
+++ b/orange_navigation/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>orange_navigation</name>
-  <version>0.4.1</version>
+  <version>0.5.0</version>
   <description>ROS2 navigation for the orange robot</description>
   <maintainer email="shunki.shibuya.5v@stu.hosei.ac.jp">Shibuya</maintainer>
   <maintainer email="koki.kubota.8p@stu.hosei.ac.jp">Kubota</maintainer>

--- a/orange_sensor_tools/CMakeLists.txt
+++ b/orange_sensor_tools/CMakeLists.txt
@@ -7,9 +7,47 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(laser_geometry REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(pcl_ros REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(PCL REQUIRED)
+
+set(dependencies
+  rclcpp
+  rclcpp_action
+  rclcpp_lifecycle
+  std_msgs
+  sensor_msgs
+  laser_geometry
+  tf2
+  tf2_ros
+  pcl_ros
+  Eigen3
+  PCL
+)
+
+# build
+add_executable(laserscan_multi_merger src/laserscan_multi_merger.cpp)
+ament_target_dependencies(laserscan_multi_merger ${dependencies})
+target_include_directories(laserscan_multi_merger PUBLIC ${EIGEN_INCLUDE_DIRS})
+target_include_directories(laserscan_multi_merger PUBLIC ${PCL_INCLUDE_DIRS})
+target_link_libraries(laserscan_multi_merger ${PCL_LIBRARIES})
+
+install(TARGETS laserscan_multi_merger
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
 
 # install
-install(DIRECTORY launch config
+install(DIRECTORY src launch config
   DESTINATION share/${PROJECT_NAME}/
 )
 

--- a/orange_sensor_tools/launch/laserscan_multi_merger.launch.xml
+++ b/orange_sensor_tools/launch/laserscan_multi_merger.launch.xml
@@ -1,0 +1,25 @@
+<launch>
+
+  <arg name="use_sim_time" default="true" />
+
+  <arg name="destination_frame" default="velodyne_link" />
+  <arg name="cloud_destination_topic" default="/merged_cloud" />
+  <arg name="scan_destination_topic" default="/merged_scan" />
+  <arg name="laserscan_topics" default="/hokuyo_scan /velodyne_scan" />
+
+  <!-- laserscan_multi_merger -->
+  <node pkg="orange_sensor_tools" exec="laserscan_multi_merger">
+		<param name="destination_frame" value="$(var destination_frame)" />
+		<param name="cloud_destination_topic" value="$(var cloud_destination_topic)" />
+		<param name="scan_destination_topic" value="$(var scan_destination_topic)" />
+		<param name="laserscan_topics" value="$(var laserscan_topics)" />
+    <!-- LIST OF THE LASER SCAN TOPICS TO SUBSCRIBE -->
+		<param name="angle_min" value="-2.65" />
+		<param name="angle_max" value="2.65" />
+		<param name="angle_increment" value="0.0087" />
+		<param name="scan_time" value="0.3333" />
+		<param name="range_min" value="0.2" />
+		<param name="range_max" value="100.0" />
+  </node>
+
+</launch>

--- a/orange_sensor_tools/launch/laserscan_multi_merger.launch.xml
+++ b/orange_sensor_tools/launch/laserscan_multi_merger.launch.xml
@@ -2,6 +2,7 @@
 
   <arg name="use_sim_time" default="true" />
 
+  <arg name="delete_intensity" default="false" />
   <arg name="destination_frame" default="velodyne_link" />
   <arg name="cloud_destination_topic" default="/merged_cloud" />
   <arg name="scan_destination_topic" default="/merged_scan" />
@@ -9,6 +10,7 @@
 
   <!-- laserscan_multi_merger -->
   <node pkg="orange_sensor_tools" exec="laserscan_multi_merger">
+		<param name="delete_intensity" value="$(var delete_intensity)" />
 		<param name="destination_frame" value="$(var destination_frame)" />
 		<param name="cloud_destination_topic" value="$(var cloud_destination_topic)" />
 		<param name="scan_destination_topic" value="$(var scan_destination_topic)" />

--- a/orange_sensor_tools/package.xml
+++ b/orange_sensor_tools/package.xml
@@ -2,15 +2,26 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>orange_sensor_tools</name>
-  <version>0.4.1</version>
+  <version>0.5.0</version>
   <description>ROS2 sensor processing tools for the orange robot</description>
   <maintainer email="shunki.shibuya.5v@stu.hosei.ac.jp">Shibuya</maintainer>
   <maintainer email="koki.kubota.8p@stu.hosei.ac.jp">Kubota</maintainer>
   <maintainer email="kimihiro.mori.4k@stu.hosei.ac.jp">Mori</maintainer>
   <license>Apache-2.0</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>sensor_msgs</depend>
+  <depend>libpcl-all-dev</depend>
+  <depend>pcl_ros</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>laser_geometry</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
+  <depend>rclcpp_lifecycle</depend>
   <depend>pointcloud_to_laserscan</depend>
   <depend>robot_localization</depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/orange_sensor_tools/package.xml
+++ b/orange_sensor_tools/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>orange_sensor_tools</name>
-  <version>0.5.0</version>
+  <version>0.0.0</version>
   <description>ROS2 sensor processing tools for the orange robot</description>
   <maintainer email="shunki.shibuya.5v@stu.hosei.ac.jp">Shibuya</maintainer>
   <maintainer email="koki.kubota.8p@stu.hosei.ac.jp">Kubota</maintainer>

--- a/orange_sensor_tools/src/laserscan_multi_merger.cpp
+++ b/orange_sensor_tools/src/laserscan_multi_merger.cpp
@@ -52,6 +52,8 @@ private:
   double scan_time;
   double range_min;
   double range_max;
+  
+  bool delete_intensity;
 
   string destination_frame;
   string cloud_destination_topic;
@@ -71,6 +73,7 @@ LaserscanMerger::LaserscanMerger() : Node("laserscan_multi_merger")
   this->declare_parameter("scan_time", 0.0);
   this->declare_parameter("range_min", 0.0);
   this->declare_parameter("range_max", 25.0);
+  this->declare_parameter("delete_intensity", false);
 
   this->get_parameter("destination_frame", destination_frame);
   this->get_parameter("cloud_destination_topic", cloud_destination_topic);
@@ -82,6 +85,7 @@ LaserscanMerger::LaserscanMerger() : Node("laserscan_multi_merger")
   this->get_parameter("scan_time", scan_time);
   this->get_parameter("range_min", range_min);
   this->get_parameter("range_max", range_max);
+  this->get_parameter("delete_intensity", delete_intensity);
 
   param_callback_handle_ = this->add_on_set_parameters_callback(
     std::bind(&LaserscanMerger::reconfigureCallback, this, std::placeholders::_1));
@@ -227,6 +231,13 @@ void LaserscanMerger::scanCallback(sensor_msgs::msg::LaserScan::SharedPtr scan, 
     if (topic.compare(input_topics[i]) == 0)
     {
       pcl_conversions::toPCL(tmpCloud2, clouds[i]);
+
+      if (delete_intensity)
+      {
+        pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_without_intensity(new pcl::PointCloud<pcl::PointXYZ>);
+        pcl::fromPCLPointCloud2(clouds[i], *cloud_without_intensity);
+        pcl::toPCLPointCloud2(*cloud_without_intensity, clouds[i]);
+      }
       clouds_modified[i] = true;
     }
   }

--- a/orange_sensor_tools/src/laserscan_multi_merger.cpp
+++ b/orange_sensor_tools/src/laserscan_multi_merger.cpp
@@ -1,0 +1,338 @@
+#include <string.h>
+#include <vector>
+#include <Eigen/Dense>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <tf2/exceptions.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <laser_geometry/laser_geometry.hpp>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
+#include "pcl_ros/transforms.hpp"
+
+#include "sensor_msgs/msg/point_cloud2.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+
+using namespace std;
+using namespace pcl;
+
+class LaserscanMerger : public rclcpp::Node
+{
+public:
+  LaserscanMerger();
+  void scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr scan, std::string topic);
+  void pointcloud_to_laserscan(Eigen::MatrixXf points, pcl::PCLPointCloud2 *merged_cloud);
+  rcl_interfaces::msg::SetParametersResult reconfigureCallback(const std::vector<rclcpp::Parameter> &parameters);
+
+private:
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler_;
+  laser_geometry::LaserProjection projector_;
+  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tfListener_;
+  OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
+
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr point_cloud_publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr laser_scan_publisher_;
+  std::vector<rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr> scan_subscribers;
+  std::vector<bool> clouds_modified;
+
+  std::vector<pcl::PCLPointCloud2> clouds;
+  std::vector<string> input_topics;
+
+  void laserscan_topic_parser();
+
+  double angle_min;
+  double angle_max;
+  double angle_increment;
+  double time_increment;
+  double scan_time;
+  double range_min;
+  double range_max;
+
+  string destination_frame;
+  string cloud_destination_topic;
+  string scan_destination_topic;
+  string laserscan_topics;
+};
+
+LaserscanMerger::LaserscanMerger() : Node("laserscan_multi_merger")
+{
+  this->declare_parameter<std::string>("destination_frame", "cart_frame");
+  this->declare_parameter<std::string>("cloud_destination_topic", "/merged_cloud");
+  this->declare_parameter<std::string>("scan_destination_topic", "/scan_multi");
+  this->declare_parameter<std::string>("laserscan_topics", "");
+  this->declare_parameter("angle_min", -3.14);
+  this->declare_parameter("angle_max", 3.14);
+  this->declare_parameter("angle_increment", 0.0058);
+  this->declare_parameter("scan_time", 0.0);
+  this->declare_parameter("range_min", 0.0);
+  this->declare_parameter("range_max", 25.0);
+
+  this->get_parameter("destination_frame", destination_frame);
+  this->get_parameter("cloud_destination_topic", cloud_destination_topic);
+  this->get_parameter("scan_destination_topic", scan_destination_topic);
+  this->get_parameter("laserscan_topics", laserscan_topics);
+  this->get_parameter("angle_min", angle_min);
+  this->get_parameter("angle_max", angle_max);
+  this->get_parameter("angle_increment", angle_increment);
+  this->get_parameter("scan_time", scan_time);
+  this->get_parameter("range_min", range_min);
+  this->get_parameter("range_max", range_max);
+
+  param_callback_handle_ = this->add_on_set_parameters_callback(
+    std::bind(&LaserscanMerger::reconfigureCallback, this, std::placeholders::_1));
+
+  tf_buffer_ = std::make_unique<tf2_ros::Buffer>(this->get_clock());
+  tfListener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+
+  this->laserscan_topic_parser();
+
+  point_cloud_publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(cloud_destination_topic.c_str(), rclcpp::SensorDataQoS());
+  laser_scan_publisher_ = this->create_publisher<sensor_msgs::msg::LaserScan>(scan_destination_topic.c_str(), rclcpp::SensorDataQoS());
+}
+
+rcl_interfaces::msg::SetParametersResult LaserscanMerger::reconfigureCallback(const std::vector<rclcpp::Parameter> &parameters)
+{
+  rcl_interfaces::msg::SetParametersResult result;
+
+  for (auto parameter : parameters)
+  {
+    const auto &type = parameter.get_type();
+    const auto &name = parameter.get_name();
+
+    // Make sure it is a double value
+    if (type == rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE)
+    {
+      double value = parameter.as_double();
+
+      if (name == "angle_min")
+      {
+        this->angle_min = value;
+      }
+      else if (name == "angle_max")
+      {
+        this->angle_max = value;
+      }
+      else if (name == "angle_increment")
+      {
+        this->angle_increment = value;
+      }
+      else if (name == "time_increment")
+      {
+        this->time_increment = value;
+      }
+      else if (name == "scan_time")
+      {
+        this->scan_time = value;
+      }
+      else if (name == "range_min")
+      {
+        this->range_min = value;
+      }
+      else if (name == "range_max")
+      {
+        this->range_max = value;
+      }
+    }
+  }
+
+  result.successful = true;
+  return result;
+}
+
+void LaserscanMerger::laserscan_topic_parser()
+{
+  // LaserScan topics to subscribe
+  std::map<std::string, std::vector<std::string>> topics;
+
+  istringstream iss(laserscan_topics);
+  set<string> tokens;
+  copy(istream_iterator<string>(iss), istream_iterator<string>(), inserter<set<string>>(tokens, tokens.begin()));
+  std::vector<string> tmp_input_topics;
+
+  while (!tokens.empty())
+  {
+    RCLCPP_INFO(this->get_logger(), "Waiting for topics ...");
+    sleep(1);
+
+    topics = this->get_topic_names_and_types();
+
+    for (const auto &topic_it : topics)
+    {
+      std::vector<std::string> topic_types = topic_it.second;
+
+      if (std::find(topic_types.begin(), topic_types.end(), "sensor_msgs/msg/LaserScan") != topic_types.end() && tokens.erase(topic_it.first) > 0)
+      {
+        tmp_input_topics.push_back(topic_it.first);
+      }
+    }
+  }
+
+  sort(tmp_input_topics.begin(), tmp_input_topics.end());
+  std::vector<string>::iterator last = std::unique(tmp_input_topics.begin(), tmp_input_topics.end());
+  tmp_input_topics.erase(last, tmp_input_topics.end());
+
+  // Do not re-subscribe if the topics are the same
+  if ((tmp_input_topics.size() != input_topics.size()) || !equal(tmp_input_topics.begin(), tmp_input_topics.end(), input_topics.begin()))
+  {
+    input_topics = tmp_input_topics;
+
+    if (input_topics.size() > 0)
+    {
+      scan_subscribers.resize(input_topics.size());
+      clouds_modified.resize(input_topics.size());
+      clouds.resize(input_topics.size());
+      RCLCPP_INFO(this->get_logger(), "Subscribing to topics\t%ld", scan_subscribers.size());
+      for (std::vector<int>::size_type i = 0; i < input_topics.size(); ++i)
+      {
+        // workaround for std::bind https://github.com/ros2/rclcpp/issues/583
+        std::function<void(const sensor_msgs::msg::LaserScan::SharedPtr)> callback =
+          std::bind(
+            &LaserscanMerger::scanCallback,
+            this, std::placeholders::_1, input_topics[i]);
+        scan_subscribers[i] = this->create_subscription<sensor_msgs::msg::LaserScan>(input_topics[i].c_str(), rclcpp::SensorDataQoS(), callback);
+        clouds_modified[i] = false;
+        cout << input_topics[i] << " ";
+      }
+    }
+    else
+    {
+      RCLCPP_INFO(this->get_logger(), "Not subscribed to any topic.");
+    }
+  }
+}
+
+void LaserscanMerger::scanCallback(sensor_msgs::msg::LaserScan::SharedPtr scan, std::string topic)
+{
+  sensor_msgs::msg::PointCloud2 tmpCloud1, tmpCloud2;
+
+  try
+  {
+    // Verify that TF knows how to transform from the received scan to the destination scan frame
+    tf_buffer_->lookupTransform(scan->header.frame_id.c_str(), destination_frame.c_str(), scan->header.stamp, rclcpp::Duration(1, 0));
+    projector_.transformLaserScanToPointCloud(scan->header.frame_id, *scan, tmpCloud1, *tf_buffer_, range_max);
+    pcl_ros::transformPointCloud(destination_frame.c_str(), tmpCloud1, tmpCloud2, *tf_buffer_);
+  }
+  catch (tf2::TransformException &ex)
+  {
+    return;
+  }
+
+  for (std::vector<int>::size_type i = 0; i < input_topics.size(); i++)
+  {
+    if (topic.compare(input_topics[i]) == 0)
+    {
+      pcl_conversions::toPCL(tmpCloud2, clouds[i]);
+      clouds_modified[i] = true;
+    }
+  }
+
+  // Count how many scans we have
+  std::vector<int>::size_type totalClouds = 0;
+  for (std::vector<int>::size_type i = 0; i < clouds_modified.size(); i++)
+  {
+    if (clouds_modified[i])
+    {
+      totalClouds++;
+    }
+  }
+
+  // Go ahead only if all subscribed scans have arrived
+  if (totalClouds == clouds_modified.size())
+  {
+    pcl::PCLPointCloud2 merged_cloud = clouds[0];
+    clouds_modified[0] = false;
+
+    for (std::vector<int>::size_type i = 1; i < clouds_modified.size(); i++)
+    {
+#if PCL_VERSION_COMPARE(>=, 1, 10, 0)
+      merged_cloud += clouds[i];
+#else
+      pcl::concatenatePointCloud(merged_cloud, clouds[i], merged_cloud);
+#endif
+
+      clouds_modified[i] = false;
+    }
+
+    Eigen::MatrixXf points;
+
+    pcl::getPointCloudAsEigen(merged_cloud, points);
+
+    pointcloud_to_laserscan(points, &merged_cloud);
+
+    // Publish point cloud after publishing laser scan as for some reason moveFromPCL is causing getPointCloudAsEigen to
+    // throw a segmentation fault crash
+    std::shared_ptr<sensor_msgs::msg::PointCloud2> cloud_msg = std::make_shared<sensor_msgs::msg::PointCloud2>();
+
+    pcl_conversions::moveFromPCL(merged_cloud, *cloud_msg);
+
+    point_cloud_publisher_->publish(*cloud_msg);
+  }
+}
+
+void LaserscanMerger::pointcloud_to_laserscan(Eigen::MatrixXf points, pcl::PCLPointCloud2 *merged_cloud)
+{
+  sensor_msgs::msg::LaserScan output;
+  output.header = pcl_conversions::fromPCL(merged_cloud->header);
+  output.angle_min = this->angle_min;
+  output.angle_max = this->angle_max;
+  output.angle_increment = this->angle_increment;
+  output.time_increment = this->time_increment;
+  output.scan_time = this->scan_time;
+  output.range_min = this->range_min;
+  output.range_max = this->range_max;
+
+  uint32_t ranges_size = std::ceil((output.angle_max - output.angle_min) / output.angle_increment);
+  output.ranges.assign(ranges_size, std::numeric_limits<double>::infinity());
+
+  for (int i = 0; i < points.cols(); i++)
+  {
+    const float &x = points(0, i);
+    const float &y = points(1, i);
+    const float &z = points(2, i);
+
+    if (std::isnan(x) || std::isnan(y) || std::isnan(z))
+    {
+      RCLCPP_DEBUG(this->get_logger(), "rejected for nan in point(%f, %f, %f)\n", x, y, z);
+      continue;
+    }
+
+    double range_sq = pow(y, 2) + pow(x, 2);
+    double range_min_sq_ = output.range_min * output.range_min;
+    if (range_sq < range_min_sq_)
+    {
+      RCLCPP_DEBUG(this->get_logger(), "rejected for range %f below minimum value %f. Point: (%f, %f, %f)", range_sq, range_min_sq_, x, y, z);
+      continue;
+    }
+
+    double angle = atan2(y, x);
+    if (angle < output.angle_min || angle > output.angle_max)
+    {
+      RCLCPP_DEBUG(this->get_logger(), "rejected for angle %f not in range (%f, %f)\n", angle, output.angle_min, output.angle_max);
+      continue;
+    }
+
+    int index = (angle - output.angle_min) / output.angle_increment;
+    if (output.ranges[index] * output.ranges[index] > range_sq)
+    {
+      output.ranges[index] = sqrt(range_sq);
+    }
+  }
+
+  laser_scan_publisher_->publish(output);
+}
+
+int main(int argc, char **argv)
+{
+  rclcpp::init(argc, argv);
+
+  rclcpp::spin(std::make_shared<LaserscanMerger>());
+
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/orange_slam/config/offline_slam_toolbox_params.yaml
+++ b/orange_slam/config/offline_slam_toolbox_params.yaml
@@ -13,7 +13,7 @@ slam_toolbox:
     odom_frame: odom
     map_frame: map
     base_frame: base_footprint
-    scan_topic: /velodyne_scan
+    scan_topic: /merged_scan
     mode: mapping #localization
 
     # if you'd like to immediately start continuing a map at a given pose

--- a/orange_slam/config/online_slam_toolbox_params.yaml
+++ b/orange_slam/config/online_slam_toolbox_params.yaml
@@ -13,7 +13,7 @@ slam_toolbox:
     odom_frame: odom
     map_frame: map
     base_frame: base_footprint
-    scan_topic: /velodyne_scan
+    scan_topic: /merged_scan
     mode: mapping #localization
 
     # if you'd like to immediately start continuing a map at a given pose

--- a/orange_slam/package.xml
+++ b/orange_slam/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>orange_slam</name>
-  <version>0.4.1</version>
+  <version>0.5.0</version>
   <description>ROS2 slam starting tools for the orange robot</description>
   <maintainer email="shunki.shibuya.5v@stu.hosei.ac.jp">Shibuya</maintainer>
   <maintainer email="koki.kubota.8p@stu.hosei.ac.jp">Kubota</maintainer>

--- a/orange_slam/package.xml
+++ b/orange_slam/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>orange_slam</name>
-  <version>0.5.0</version>
+  <version>0.0.0</version>
   <description>ROS2 slam starting tools for the orange robot</description>
   <maintainer email="shunki.shibuya.5v@stu.hosei.ac.jp">Shibuya</maintainer>
   <maintainer email="koki.kubota.8p@stu.hosei.ac.jp">Kubota</maintainer>

--- a/orange_teleop/package.xml
+++ b/orange_teleop/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>orange_teleop</name>
-  <version>0.5.0</version>
+  <version>0.0.0</version>
   <description>ROS2 teleoperation tools for the orange robot</description>
   <maintainer email="shunki.shibuya.5v@stu.hosei.ac.jp">Shibuya</maintainer>
   <maintainer email="koki.kubota.8p@stu.hosei.ac.jp">Kubota</maintainer>

--- a/orange_teleop/package.xml
+++ b/orange_teleop/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>orange_teleop</name>
-  <version>0.4.1</version>
+  <version>0.5.0</version>
   <description>ROS2 teleoperation tools for the orange robot</description>
   <maintainer email="shunki.shibuya.5v@stu.hosei.ac.jp">Shibuya</maintainer>
   <maintainer email="koki.kubota.8p@stu.hosei.ac.jp">Kubota</maintainer>

--- a/orange_teleop/setup.py
+++ b/orange_teleop/setup.py
@@ -7,7 +7,7 @@ package_name = 'orange_teleop'
 
 setup(
   name=package_name,
-  version='0.4.1',
+  version='0.0.0',
   packages=find_packages(exclude=[]),
   data_files=[
     ('share/ament_index/resource_index/packages', ['resource/' + package_name]),


### PR DESCRIPTION
## 概要

- `orange_ros2/orange_sensor_tools/`にscan multi mergerを追加。

### なぜこのタスクを行うのか

- slam_toolboxを利用して地図を作成する際に、velodyneのscanしか利用できていなかったため。

### やったこと
[iralabdisco/ira_laser_tools](https://github.com/iralabdisco/ira_laser_tools)の以下のPRにROS2 Humbleのサポートを追加したという記述があったため、該当するソースコードを`orange_ros2/orange_sensor_tools/`に`src`フォルダを作って引っ張ってきました。

・[Add support for ROS2 humble #47](https://github.com/iralabdisco/ira_laser_tools/pull/47)

ただし、そのまま実行するとscanの`intensities`の有無が原因で、scanをmergeする際にエラーが出ていたので、応急処置的に`delete_intensity`というパラメータを作り、以下の処理を加えました。

https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2/blob/72c798c03761ef8d2f2560cc6782f8d209f621c7/orange_sensor_tools/src/laserscan_multi_merger.cpp#L235-L240

<!--
### できるようになること

- 

### できなくなること

- 
-->
### その他
<!-- レビューアーに確認してもらいたいこと -->

- package.xmlのversionを毎度、変更するのが面倒になってきたのでREADME.mdだけ変更するようにしました。
