### PR TITLE
fix joycon node

### DIFF
--- a/orange_teleop/config/elecom.yaml
+++ b/orange_teleop/config/elecom.yaml
@@ -12,5 +12,5 @@ teleop_twist_joy_node:
     scale_angular:
       yaw: 0.4
 
-    enable_button: 9  # R1 shoulder button
-    enable_turbo_button: 7  # R2 shoulder button
+    enable_button: 4  # L1 shoulder button
+    enable_turbo_button: 5  # R1 shoulder button

--- a/orange_teleop/launch/teleop_joy.launch.xml
+++ b/orange_teleop/launch/teleop_joy.launch.xml
@@ -4,8 +4,8 @@
   <arg name="cmd_vel" default="/cmd_vel"/>
   <arg name="config_file_path" default="$(find-pkg-share orange_teleop)/config/elecom.yaml"/>
   <!-- joy_node -->
-  <node pkg="joy" exec="joy_node">
-    <param name="dev" value="$(var joy_dev)"/>
+  <node pkg="joy_linux" exec="joy_linux_node">
+    <param name="dev_name" value="$(var joy_dev)"/>
     <param name="deadzone" value="0.3"/>
     <param name="autorepeat_rate" value="20.0"/>
   </node>

--- a/orange_teleop/package.xml
+++ b/orange_teleop/package.xml
@@ -12,6 +12,7 @@
   <depend>rclpy</depend>
   <depend>teleop_twist_joy</depend>
   <depend>xterm</depend>
+  <depend>joy_linux</depend>
   <export>
     <build_type>ament_python</build_type>
   </export>


### PR DESCRIPTION
## 概要

- Joyconでロボットを操作できなかった問題の改善。

### なぜこのタスクを行うのか

- ウェイポイントナビゲーションのためにJoyconでロボットを操作させる必要があるため。

### やったこと

- joy_nodeからjoy_linux_nodeへの変更。

### できるようになること

- joyconを用いたロボット操作。

### その他
<!-- レビューアーに確認してもらいたいこと -->

- モータドライバの遅延の問題が発生している可能性があります。
- 参考リンク；https://qiita.com/thun_build/items/6dd1ac4e0c11dcc0fa26
- 今回のPRで行ったインストールは以下の3つです。
$ sudo apt install ros-foxy-joy-linux
$ sudo apt install ros-foxy-joy-linux-dbgsym
$ sudo apt install joystick
