### PR TITLE
Feature/fusion scan

### DIFF
--- a/orange_bringup/launch/orange_robot.launch.xml
+++ b/orange_bringup/launch/orange_robot.launch.xml
@@ -71,4 +71,19 @@
     <remap from="/scan" to="/hokuyo_scan"/>
   </node>
   <!-- imu TODO -->
+  <!-- pointcloud_to_laserscan -->
+  <include file="$(find-pkg-share orange_sensor_tools)/launch/pointcloud_to_laserscan.launch.xml">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
+    <arg name="cloud_in" value="$(var velodyne_points_topic)"/>
+    <arg name="scan_out" value="$(var velodyne_scan_topic)"/>
+  </include>
+  <!-- laserscan_multi_merger -->
+  <include file="$(find-pkg-share orange_sensor_tools)/launch/laserscan_multi_merger.launch.xml">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
+    <arg name="delete_intensity" value="true"/>
+    <arg name="destination_frame" value="$(var velodyne_frame)"/>
+    <arg name="cloud_destination_topic" value="$(var merged_cloud_topic)"/>
+    <arg name="scan_destination_topic" value="$(var merged_scan_topic)"/>
+    <arg name="laserscan_topics" value="$(var hokuyo_scan_topic) $(var velodyne_scan_topic)"/>
+  </include>
 </launch>

--- a/orange_bringup/launch/orange_robot.launch.xml
+++ b/orange_bringup/launch/orange_robot.launch.xml
@@ -20,6 +20,12 @@
   <arg name="publish_odom" default="true"/>
   <arg name="odom_header_frame" default="odom"/>
   <arg name="odom_child_frame" default="base_footprint"/>
+  <arg name="velodyne_frame" default="velodyne"/>
+  <arg name="hokuyo_scan_topic" default="/hokuyo_scan"/>
+  <arg name="velodyne_scan_topic" default="/velodyne_scan"/>
+  <arg name="velodyne_points_topic" default="/velodyne_points"/>
+  <arg name="merged_cloud_topic" default="/merged_cloud"/>
+  <arg name="merged_scan_topic" default="/merged_scan"/>
   <arg name="xacro_file_path" default="$(find-pkg-share orange_description)/xacro/orange_robot.xacro"/>
   <arg name="motor_driver_config_file_path" default="$(find-pkg-share orange_bringup)/config/motor_driver_params.yaml"/>
   <!-- robot_state_publisher -->


### PR DESCRIPTION
## 概要

- 3D-LiDARから得られる3次元の点群情報を2次元に潰した上で、2D-LiDARから得られるものとFusionした。

### なぜこのタスクを行うのか

- 障害物認識の精度向上のため。

### やったこと

- orange_ros2/orange_bringup内のorange_robot.launch.xml内に<pointcloud_to_laserscan>と<laserscan_multi_merger>を追加した。
 <img src="https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2/assets/88425011/6f899082-8837-45ef-aba1-d2536ea66c39" width="600px">

### できるようになること

- Fusion Scan。


### その他
<!-- レビューアーに確認してもらいたいこと -->

- 実機での動作も確認してあります。
