### PR TITLE
fix_icm_launch

### DIFF
--- a/orange_bringup/launch/orange_robot.launch.xml
+++ b/orange_bringup/launch/orange_robot.launch.xml
@@ -90,7 +90,7 @@
     <param name="angle_min" value="-1.22"/>
     <remap from="/scan" to="/hokuyo_scan"/>
   </node>
-  <!-- imu TODO -->
+  <!-- imu  -->
   <node pkg="icm_20948" exec="imu_node" output="screen">
     <param name="port" value="$(var port)"/>
     <param name="time_out" value="$(var time_out)"/>

--- a/orange_bringup/launch/orange_robot.launch.xml
+++ b/orange_bringup/launch/orange_robot.launch.xml
@@ -25,7 +25,7 @@
   <arg name="port" default="/dev/sensors/imu"/>
   <arg name="time_out" default="0.5"/>
   <arg name="baudrate" default="115200"/>
-  <arg name="imu_topic" default="imu"/>
+  <arg name="imu_topic" default="/imu"/>
   <arg name="frame_id" default="imu_link"/>
   <arg name="velodyne_scan_topic" default="/velodyne_scan"/>
   <arg name="velodyne_points_topic" default="/velodyne_points"/>

--- a/orange_bringup/launch/orange_robot.launch.xml
+++ b/orange_bringup/launch/orange_robot.launch.xml
@@ -22,6 +22,11 @@
   <arg name="odom_child_frame" default="base_footprint"/>
   <arg name="velodyne_frame" default="velodyne"/>
   <arg name="hokuyo_scan_topic" default="/hokuyo_scan"/>
+  <arg name="port" default="/dev/sensors/imu"/>
+  <arg name="time_out" default="0.5"/>
+  <arg name="baudrate" default="115200"/>
+  <arg name="imu_topic" default="imu"/>
+  <arg name="frame_id" default="imu_link"/>
   <arg name="velodyne_scan_topic" default="/velodyne_scan"/>
   <arg name="velodyne_points_topic" default="/velodyne_points"/>
   <arg name="merged_cloud_topic" default="/merged_cloud"/>
@@ -86,6 +91,13 @@
     <remap from="/scan" to="/hokuyo_scan"/>
   </node>
   <!-- imu TODO -->
+  <node pkg="icm_20948" exec="imu_node" output="screen">
+    <param name="port" value="$(var port)"/>
+    <param name="time_out" value="$(var time_out)"/>
+    <param name="baudrate" value="$(var baudrate)"/>
+    <param name="imu_topic" value="$(var imu_topic)"/>
+    <param name="frame_id" value="$(var frame_id)"/>
+  </node>
   <!-- pointcloud_to_laserscan -->
   <include file="$(find-pkg-share orange_sensor_tools)/launch/pointcloud_to_laserscan.launch.xml">
     <arg name="use_sim_time" value="$(var use_sim_time)"/>

--- a/orange_bringup/launch/orange_robot.launch.xml
+++ b/orange_bringup/launch/orange_robot.launch.xml
@@ -91,7 +91,7 @@
     <remap from="/scan" to="/hokuyo_scan"/>
   </node>
   <!-- imu  -->
-  <node pkg="icm_20948" exec="imu_node" output="screen">
+  <node pkg="icm_20948" exec="imu_node">
     <param name="port" value="$(var port)"/>
     <param name="time_out" value="$(var time_out)"/>
     <param name="baudrate" value="$(var baudrate)"/>

--- a/orange_bringup/package.xml
+++ b/orange_bringup/package.xml
@@ -17,6 +17,7 @@
   <depend>python3-pymodbus</depend>
   <depend>velodyne</depend>
   <depend>urg_node</depend>
+  <depend>icm_20948</depend>
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/orange_ros2.rosinstall
+++ b/orange_ros2.rosinstall
@@ -2,4 +2,7 @@
     local-name: velodyne
     uri: https://github.com/ros-drivers/velodyne.git
     version: ros2
-
+- git:
+    local-name:icm_20948
+    uri:  https://github.com/Alpaca-zip/icm_20948.git
+    version: ros2

--- a/orange_ros2.rosinstall
+++ b/orange_ros2.rosinstall
@@ -4,5 +4,5 @@
     version: ros2
 - git:
     local-name: icm_20948
-    uri: https://github.com/Alpaca-zip/icm_20948.git
+    uri: https://github.com/KBKN-Autonomous-Robotics-Lab/icm_20948.git
     version: humble-devel

--- a/orange_ros2.rosinstall
+++ b/orange_ros2.rosinstall
@@ -3,6 +3,6 @@
     uri: https://github.com/ros-drivers/velodyne.git
     version: ros2
 - git:
-    local-name:icm_20948
-    uri:  https://github.com/Alpaca-zip/icm_20948.git
-    version: ros2
+    local-name: icm_20948
+    uri: https://github.com/Alpaca-zip/icm_20948.git
+    version: humble-devel


### PR DESCRIPTION
## 概要

- IMUセンサーをorange_ros2内で使用するための移植作業。

### なぜこのタスクを行うのか

- IMUセンサを搭載し自己位置推定の精度向上を図るため。

### やったこと

- orange_robot.launch.xml内にIMUのnodeを追記。
-  <img src="https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2/assets/88425011/5f753a6e-222c-45e6-bda8-afe6ee034df1" width="500px"> 
### できるようになること

- 実機でIMUを使用可能に。
