### PR TITLE
fix_motor_param

### DIFF
--- a/orange_bringup/config/motor_driver_params.yaml
+++ b/orange_bringup/config/motor_driver_params.yaml
@@ -25,8 +25,8 @@ motor_driver_node:
     set_decel_time_right: 200 # ms
 
     # Maximum rpm
-    max_left_rpm: 50
-    max_right_rpm: 50
+    max_left_rpm: 30
+    max_right_rpm: 30
     # Width of rpm to be regarded as 0
     # If 3, then -3 to 3 is considered rpm 0
     deadband_rpm: 3

--- a/orange_bringup/config/motor_driver_params.yaml
+++ b/orange_bringup/config/motor_driver_params.yaml
@@ -25,8 +25,8 @@ motor_driver_node:
     set_decel_time_right: 200 # ms
 
     # Maximum rpm
-    max_left_rpm: 30
-    max_right_rpm: 30
+    max_left_rpm: 50
+    max_right_rpm: 50
     # Width of rpm to be regarded as 0
     # If 3, then -3 to 3 is considered rpm 0
     deadband_rpm: 3

--- a/orange_bringup/config/motor_driver_params.yaml
+++ b/orange_bringup/config/motor_driver_params.yaml
@@ -4,17 +4,17 @@ motor_driver_node:
     # Default: 8 inches wheel
     ###############################
     # Wheel radius
-    left_wheel_radius: 0.1015 # meter
-    right_wheel_radius: 0.1015 # meter
+    left_wheel_radius: 0.09767 # meter
+    right_wheel_radius: 0.09767 # meter
     # For odometry computation
-    computation_left_wheel_radius: 0.1015 # meter
-    computation_right_wheel_radius: 0.1015 # meter
+    computation_left_wheel_radius: 0.0978 # meter
+    computation_right_wheel_radius: 0.0978 # meter
     # Encoder CPR(counts per revolution)
     cpr: 16385
     ###############################
 
     # Distance between Wheels
-    wheels_base_width: 0.5668 # meter
+    wheels_base_width: 0.6048 # meter
     # Motor automatically stops if no topics are received for a certain period of time
     callback_timeout: 0.5 # seconds
 
@@ -25,8 +25,8 @@ motor_driver_node:
     set_decel_time_right: 200 # ms
 
     # Maximum rpm
-    max_left_rpm: 150
-    max_right_rpm: 150
+    max_left_rpm: 30
+    max_right_rpm: 30
     # Width of rpm to be regarded as 0
     # If 3, then -3 to 3 is considered rpm 0
     deadband_rpm: 3


### PR DESCRIPTION
## 概要

- モータードライバのパラメータ調整。

### なぜこのタスクを行うのか

- 正確な走行を行うため。

### やったこと

- left_wheel_radius, right_wheel_radius, computation_left_wheel_radius, computation_right_wheel_radiusの値の調整。
- 10m進ように設定し、実際に進んだ距離と比較。
- 中庭を一周した後のオドメトリの値確認。

### できるようになること

- 正確なオドメトリ測定。
