### PR TITLE
Feature/launch for ros2bag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ You can try Navigation2 with a map created by slam_toolbox or cartographer.
 **Turn-by-turn Navigation**
 ```
 $ ros2 launch orange_gazebo orange_world.launch.xml
-$ ros2 launch orange_navigation navigation2.launch.xml slam_method:={SLAM_METHOD_NAME}
+$ ros2 launch orange_navigation navigation2.launch.xml slam_method:={SLAM_METHOD_NAME} use_sim_time:=true
 ```
 
 **Waypoint Navigation**
 ```
 $ ros2 launch orange_gazebo orange_world.launch.xml
-$ ros2 launch orange_navigation navigation2.launch.xml slam_method:={SLAM_METHOD_NAME}
-$ ros2 run orange_navigation waypoint_follower_client
+$ ros2 launch orange_navigation navigation2.launch.xml slam_method:={SLAM_METHOD_NAME} use_sim_time:=true
+$ ros2 run orange_navigation waypoint_follower_client use_sim_time:=true
 ```
 ## Sample dataset
 You can download the ros2 bag obtained from orange_world.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The following SLAM methods can be run.
 **Gazebo simulation**
 ```
 $ ros2 launch orange_gazebo orange_world.launch.xml
-$ ros2 launch orange_slam {SLAM_METHOD_NAME}.launch.xml
+$ ros2 launch orange_slam {SLAM_METHOD_NAME}.launch.xml use_sim_time:=true
 $ ros2 launch orange_teleop teleop_keyboard.launch.xml
 ```
 **ros2 bag**

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ $ ros2 launch orange_teleop teleop_keyboard.launch.xml
 ```
 **ros2 bag**
 ```
-$ ros2 bag play your_bag -r 3
+$ ros2 launch orange_bringup with_ros2bag.launch.xml
+$ ros2 bag play your_bag -r 3 --clock
 $ ros2 launch orange_slam {SLAM_METHOD_NAME}.launch.xml with_ros2bag:=true
 ```
 ## Navigation2
@@ -79,10 +80,11 @@ $ ros2 launch orange_navigation navigation2.launch.xml slam_method:={SLAM_METHOD
 $ ros2 run orange_navigation waypoint_follower_client use_sim_time:=true
 ```
 ## Sample dataset
-You can download the ros2 bag obtained from orange_world.
+You can download the ros2 bag obtained from orange_hosei.
 
-- [ros2bag_orange_hosei.zip](https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2/files/11496734/ros2bag_orange_hosei.zip)
-
+```
+$ wget --load-cookies /tmp/cookies.txt "https://drive.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://drive.google.com/uc?export=download&id=1T3eFLUSbdlLayyaVRCAf1Hfi8K1FMR4K' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1T3eFLUSbdlLayyaVRCAf1Hfi8K1FMR4K" -O ros2bag_orange_hosei.zip && rm -rf /tmp/cookies.txt
+```
 
 
 

--- a/orange_bringup/launch/orange_robot.launch.xml
+++ b/orange_bringup/launch/orange_robot.launch.xml
@@ -9,7 +9,7 @@
   <arg name="control_mode" default="3"/>
   <arg name="debug_motor" default="false"/>
   <arg name="debug_imu" default="false"/>
-  <arg name="publish_TF" default="true"/>
+  <arg name="publish_TF" default="false"/>
   <arg name="publish_odom" default="true"/>
   <arg name="twist_cmd_vel_topic" default="/cmd_vel"/>
   <arg name="cmd_vel_topic" default="/vel/cmd_vel"/>

--- a/orange_bringup/launch/orange_robot.launch.xml
+++ b/orange_bringup/launch/orange_robot.launch.xml
@@ -27,6 +27,13 @@
   <node pkg="robot_state_publisher" exec="robot_state_publisher">
     <param name="robot_description" value="$(command 'xacro $(var xacro_file_path)')"/>
   </node>
+  <!-- robot_localization -->
+  <include file="$(find-pkg-share orange_sensor_tools)/launch/localization.launch.xml">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
+    <arg name="odom_in" value="$(var odom_topic)"/>
+    <arg name="imu_in" value="$(var imu_topic)"/>
+    <arg name="fusion_odom_out" value="$(var fusion_odom_topic)"/>
+  </include>
   <!-- motor_driver_node -->
   <node pkg="orange_bringup" exec="motor_driver_node" output="screen">
     <param from="$(var motor_driver_config_file_path)"/>

--- a/orange_bringup/launch/orange_robot.launch.xml
+++ b/orange_bringup/launch/orange_robot.launch.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="use_sim_time" default="true"/>
   <!--# Control mode
       # 1: relative position control mode
       # Default: Subscribe to "/zlac8015d/pos/cmd_deg" and "/zlac8015d/pos/cmd_dist"
@@ -26,13 +25,11 @@
   <arg name="motor_driver_config_file_path" default="$(find-pkg-share orange_bringup)/config/motor_driver_params.yaml"/>
   <!-- robot_state_publisher -->
   <node pkg="robot_state_publisher" exec="robot_state_publisher">
-    <param name="use_sim_time" value="$(var use_sim_time)"/>
     <param name="robot_description" value="$(command 'xacro $(var xacro_file_path)')"/>
   </node>
   <!-- motor_driver_node -->
   <node pkg="orange_bringup" exec="motor_driver_node" output="screen">
     <param from="$(var motor_driver_config_file_path)"/>
-    <param name="use_sim_time" value="$(var use_sim_time)"/>
     <param name="port" value="/dev/ZLAC8015D"/>
     <param name="control_mode" value="$(var control_mode)"/>
     <param name="debug" value="$(var debug_motor)"/>
@@ -92,13 +89,11 @@
   </include>
   <!-- pointcloud_to_laserscan -->
   <include file="$(find-pkg-share orange_sensor_tools)/launch/pointcloud_to_laserscan.launch.xml">
-    <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="cloud_in" value="$(var velodyne_points_topic)"/>
     <arg name="scan_out" value="$(var velodyne_scan_topic)"/>
   </include>
   <!-- laserscan_multi_merger -->
   <include file="$(find-pkg-share orange_sensor_tools)/launch/laserscan_multi_merger.launch.xml">
-    <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="delete_intensity" value="true"/>
     <arg name="destination_frame" value="velodyne"/>
     <arg name="cloud_destination_topic" value="$(var merged_cloud_topic)"/>

--- a/orange_bringup/launch/orange_robot.launch.xml
+++ b/orange_bringup/launch/orange_robot.launch.xml
@@ -16,7 +16,9 @@
   <arg name="cmd_deg_topic" default="/pos/cmd_deg"/>
   <arg name="cmd_dist_topic" default="/pos/cmd_dist"/>
   <arg name="hokuyo_scan_topic" default="/hokuyo_scan"/>
+  <arg name="odom_topic" default="/odom"/>
   <arg name="imu_topic" default="/imu"/>
+  <arg name="fusion_odom_topic" default="/fusion/odom"/>
   <arg name="velodyne_scan_topic" default="/velodyne_scan"/>
   <arg name="velodyne_points_topic" default="/velodyne_points"/>
   <arg name="merged_cloud_topic" default="/merged_cloud"/>
@@ -29,7 +31,6 @@
   </node>
   <!-- robot_localization -->
   <include file="$(find-pkg-share orange_sensor_tools)/launch/localization.launch.xml">
-    <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="odom_in" value="$(var odom_topic)"/>
     <arg name="imu_in" value="$(var imu_topic)"/>
     <arg name="fusion_odom_out" value="$(var fusion_odom_topic)"/>

--- a/orange_bringup/launch/with_ros2bag.launch.xml
+++ b/orange_bringup/launch/with_ros2bag.launch.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="use_sim_time" default="true"/>
+  <arg name="velodyne_frame" default="velodyne"/>
+  <arg name="hokuyo_scan_topic" default="/hokuyo_scan"/>
+  <arg name="velodyne_scan_topic" default="/velodyne_scan"/>
+  <arg name="velodyne_points_topic" default="/velodyne_points"/>
+  <arg name="merged_cloud_topic" default="/merged_cloud"/>
+  <arg name="merged_scan_topic" default="/merged_scan"/>
+  <arg name="odom_topic" default="/odom"/>
+  <arg name="imu_topic" default="/imu"/>
+  <arg name="fusion_odom_topic" default="/fusion/odom"/>
+  <arg name="xacro_file_path" default="$(find-pkg-share orange_description)/xacro/orange_robot.xacro"/>
+  <!-- pointcloud_to_laserscan -->
+  <include file="$(find-pkg-share orange_sensor_tools)/launch/pointcloud_to_laserscan.launch.xml">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
+    <arg name="cloud_in" value="$(var velodyne_points_topic)"/>
+    <arg name="scan_out" value="$(var velodyne_scan_topic)"/>
+  </include>
+  <!-- laserscan_multi_merger -->
+  <include file="$(find-pkg-share orange_sensor_tools)/launch/laserscan_multi_merger.launch.xml">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
+    <arg name="delete_intensity" value="true"/>
+    <arg name="destination_frame" value="$(var velodyne_frame)"/>
+    <arg name="cloud_destination_topic" value="$(var merged_cloud_topic)"/>
+    <arg name="scan_destination_topic" value="$(var merged_scan_topic)"/>
+    <arg name="laserscan_topics" value="$(var hokuyo_scan_topic) $(var velodyne_scan_topic)"/>
+  </include>
+  <!-- robot_localization -->
+  <include file="$(find-pkg-share orange_sensor_tools)/launch/localization.launch.xml">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
+    <arg name="odom_in" value="$(var odom_topic)"/>
+    <arg name="imu_in" value="$(var imu_topic)"/>
+    <arg name="fusion_odom_out" value="$(var fusion_odom_topic)"/>
+  </include>
+  <!-- robot_state_publisher -->
+  <node pkg="robot_state_publisher" exec="robot_state_publisher">
+    <param name="use_sim_time" value="$(var use_sim_time)"/>
+    <param name="robot_description" value="$(command 'xacro $(var xacro_file_path)')"/>
+  </node>
+  <!-- joint_state_publisher -->
+  <node pkg="joint_state_publisher" exec="joint_state_publisher">
+    <param name="use_sim_time" value="$(var use_sim_time)"/>
+    <param name="robot_description" value="$(command 'xacro $(var xacro_file_path)')"/>
+  </node>
+</launch>

--- a/orange_bringup/package.xml
+++ b/orange_bringup/package.xml
@@ -18,6 +18,7 @@
   <depend>velodyne</depend>
   <depend>urg_node</depend>
   <depend>icm_20948</depend>
+  <depend>joint_state_publisher</depend>
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/orange_gazebo/launch/empty_world.launch.xml
+++ b/orange_gazebo/launch/empty_world.launch.xml
@@ -36,15 +36,20 @@
   </include>
   <!-- gzserver -->
   <include file="$(find-pkg-share gazebo_ros)/launch/gzserver.launch.py">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="world" value="$(var world_file_path)"/>
   </include>
   <!-- gzclient -->
-  <include file="$(find-pkg-share gazebo_ros)/launch/gzclient.launch.py"/>
+  <include file="$(find-pkg-share gazebo_ros)/launch/gzclient.launch.py">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
+  </include>
   <!-- robot_state_publisher -->
   <node pkg="robot_state_publisher" exec="robot_state_publisher">
     <param name="use_sim_time" value="$(var use_sim_time)"/>
     <param name="robot_description" value="$(command 'xacro $(var xacro_file_path)')"/>
   </node>
   <!-- spawn_entity -->
-  <node pkg="gazebo_ros" exec="spawn_entity.py" args="-entity orange_robot -topic /robot_description"/>
+  <node pkg="gazebo_ros" exec="spawn_entity.py" args="-entity orange_robot -topic /robot_description">
+    <param name="use_sim_time" value="$(var use_sim_time)"/>
+  </node>
 </launch>

--- a/orange_gazebo/launch/orange_hosei.launch.xml
+++ b/orange_gazebo/launch/orange_hosei.launch.xml
@@ -36,15 +36,20 @@
   </include>
   <!-- gzserver -->
   <include file="$(find-pkg-share gazebo_ros)/launch/gzserver.launch.py">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="world" value="$(var world_file_path)"/>
   </include>
   <!-- gzclient -->
-  <include file="$(find-pkg-share gazebo_ros)/launch/gzclient.launch.py"/>
+  <include file="$(find-pkg-share gazebo_ros)/launch/gzclient.launch.py">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
+  </include>
   <!-- robot_state_publisher -->
   <node pkg="robot_state_publisher" exec="robot_state_publisher">
     <param name="use_sim_time" value="$(var use_sim_time)"/>
     <param name="robot_description" value="$(command 'xacro $(var xacro_file_path)')"/>
   </node>
   <!-- spawn_entity -->
-  <node pkg="gazebo_ros" exec="spawn_entity.py" args="-entity orange_robot -topic /robot_description"/>
+  <node pkg="gazebo_ros" exec="spawn_entity.py" args="-entity orange_robot -topic /robot_description">
+    <param name="use_sim_time" value="$(var use_sim_time)"/>
+  </node>
 </launch>

--- a/orange_gazebo/launch/orange_igvc.launch.xml
+++ b/orange_gazebo/launch/orange_igvc.launch.xml
@@ -36,15 +36,20 @@
   </include>
   <!-- gzserver -->
   <include file="$(find-pkg-share gazebo_ros)/launch/gzserver.launch.py">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="world" value="$(var world_file_path)"/>
   </include>
   <!-- gzclient -->
-  <include file="$(find-pkg-share gazebo_ros)/launch/gzclient.launch.py"/>
+  <include file="$(find-pkg-share gazebo_ros)/launch/gzclient.launch.py">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
+  </include>
   <!-- robot_state_publisher -->
   <node pkg="robot_state_publisher" exec="robot_state_publisher">
     <param name="use_sim_time" value="$(var use_sim_time)"/>
     <param name="robot_description" value="$(command 'xacro $(var xacro_file_path)')"/>
   </node>
   <!-- spawn_entity -->
-  <node pkg="gazebo_ros" exec="spawn_entity.py" args="-entity orange_robot -topic /robot_description"/>
+  <node pkg="gazebo_ros" exec="spawn_entity.py" args="-entity orange_robot -topic /robot_description">
+    <param name="use_sim_time" value="$(var use_sim_time)"/>
+  </node>
 </launch>

--- a/orange_gazebo/launch/orange_world.launch.xml
+++ b/orange_gazebo/launch/orange_world.launch.xml
@@ -36,12 +36,12 @@
   </include>
   <!-- gzserver -->
   <include file="$(find-pkg-share gazebo_ros)/launch/gzserver.launch.py">
-    <param name="use_sim_time" value="$(var use_sim_time)"/>
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="world" value="$(var world_file_path)"/>
   </include>
   <!-- gzclient -->
   <include file="$(find-pkg-share gazebo_ros)/launch/gzclient.launch.py">
-    <param name="use_sim_time" value="$(var use_sim_time)"/>
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
   </include>
   <!-- robot_state_publisher -->
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/orange_gazebo/launch/orange_world.launch.xml
+++ b/orange_gazebo/launch/orange_world.launch.xml
@@ -36,15 +36,20 @@
   </include>
   <!-- gzserver -->
   <include file="$(find-pkg-share gazebo_ros)/launch/gzserver.launch.py">
+    <param name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="world" value="$(var world_file_path)"/>
   </include>
   <!-- gzclient -->
-  <include file="$(find-pkg-share gazebo_ros)/launch/gzclient.launch.py"/>
+  <include file="$(find-pkg-share gazebo_ros)/launch/gzclient.launch.py">
+    <param name="use_sim_time" value="$(var use_sim_time)"/>
+  </include>
   <!-- robot_state_publisher -->
   <node pkg="robot_state_publisher" exec="robot_state_publisher">
     <param name="use_sim_time" value="$(var use_sim_time)"/>
     <param name="robot_description" value="$(command 'xacro $(var xacro_file_path)')"/>
   </node>
   <!-- spawn_entity -->
-  <node pkg="gazebo_ros" exec="spawn_entity.py" args="-entity orange_robot -topic /robot_description"/>
+  <node pkg="gazebo_ros" exec="spawn_entity.py" args="-entity orange_robot -topic /robot_description">
+    <param name="use_sim_time" value="$(var use_sim_time)"/>
+  </node>
 </launch>

--- a/orange_navigation/launch/navigation2.launch.xml
+++ b/orange_navigation/launch/navigation2.launch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="use_sim_time" default="true"/>
+  <arg name="use_sim_time" default="false"/>
   <arg name="slam_method" default="slam_toolbox"/>
   <arg name="map_file_name" default="map.yaml"/>
   <arg name="rviz_config_file_path" default="$(find-pkg-share orange_description)/rviz2/navigation2.rviz"/>

--- a/orange_sensor_tools/launch/laserscan_multi_merger.launch.xml
+++ b/orange_sensor_tools/launch/laserscan_multi_merger.launch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="use_sim_time" default="true"/>
+  <arg name="use_sim_time" default="false"/>
   <arg name="delete_intensity" default="false"/>
   <arg name="destination_frame" default="velodyne"/>
   <arg name="cloud_destination_topic" default="/merged_cloud"/>
@@ -8,6 +8,7 @@
   <arg name="laserscan_topics" default="/hokuyo_scan /velodyne_scan"/>
   <!-- laserscan_multi_merger -->
   <node pkg="orange_sensor_tools" exec="laserscan_multi_merger">
+    <param name="use_sim_time" value="$(var use_sim_time)"/>
     <param name="delete_intensity" value="$(var delete_intensity)"/>
     <param name="destination_frame" value="$(var destination_frame)"/>
     <param name="cloud_destination_topic" value="$(var cloud_destination_topic)"/>

--- a/orange_sensor_tools/launch/localization.launch.xml
+++ b/orange_sensor_tools/launch/localization.launch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="use_sim_time" default="true"/>
+  <arg name="use_sim_time" default="false"/>
   <arg name="odom_in" default="/odom"/>
   <arg name="imu_in" default="/imu"/>
   <arg name="fusion_odom_out" default="/fusion/odom"/>

--- a/orange_sensor_tools/launch/pointcloud_to_laserscan.launch.xml
+++ b/orange_sensor_tools/launch/pointcloud_to_laserscan.launch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="use_sim_time" default="true"/>
+  <arg name="use_sim_time" default="false"/>
   <arg name="cloud_in" default="/velodyne_points"/>
   <arg name="scan_out" default="/velodyne_scan"/>
   <!-- pointcloud_to_laserscan -->

--- a/orange_slam/launch/cartographer.launch.xml
+++ b/orange_slam/launch/cartographer.launch.xml
@@ -11,21 +11,20 @@
   <arg name="rviz_config_file_path" default="$(find-pkg-share orange_description)/rviz2/cartographer.rviz"/>
   <arg name="slam_config_file_dir" default="$(find-pkg-share orange_slam)/config"/>
   <arg name="xacro_file_path" default="$(find-pkg-share orange_description)/xacro/orange_robot.xacro"/>
+  <let name="use_sim_time" value="true" if="$(var with_ros2bag)"/>
   <!-- rviz2 -->
   <include file="$(find-pkg-share orange_bringup)/launch/rviz2.launch.xml">
     <arg name="config_file_path" value="$(var rviz_config_file_path)"/>
   </include>
   <!-- cartographer_node -->
   <node pkg="cartographer_ros" exec="cartographer_node" args="-configuration_directory $(var slam_config_file_dir)    -configuration_basename $(var slam_config_file_name)">
-    <param if="$(var with_ros2bag)" name="use_sim_time" value="true"/>
-    <param unless="$(var with_ros2bag)" name="use_sim_time" value="$(var use_sim_time)"/>
+    <param name="use_sim_time" value="$(var use_sim_time)"/>
     <remap from="/scan_1" to="$(var scan_1)"/>
     <remap from="/scan_2" to="$(var scan_2)"/>
     <remap from="/odom" to="$(var odom)"/>
   </node>
   <!-- occupancy_grid -->
   <node pkg="cartographer_ros" exec="cartographer_occupancy_grid_node" args="-resolution $(var resolution)    -publish_period_sec $(var publish_period_sec)">
-    <param if="$(var with_ros2bag)" name="use_sim_time" value="true"/>
-    <param unless="$(var with_ros2bag)" name="use_sim_time" value="$(var use_sim_time)"/>
+    <param name="use_sim_time" value="$(var use_sim_time)"/>
   </node>
 </launch>

--- a/orange_slam/launch/cartographer.launch.xml
+++ b/orange_slam/launch/cartographer.launch.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="use_sim_time" default="false"/>
   <arg name="with_ros2bag" default="false"/>
   <arg name="scan_1" default="/velodyne_scan"/>
   <arg name="scan_2" default="/hokuyo_scan"/>
@@ -16,13 +17,15 @@
   </include>
   <!-- cartographer_node -->
   <node pkg="cartographer_ros" exec="cartographer_node" args="-configuration_directory $(var slam_config_file_dir)    -configuration_basename $(var slam_config_file_name)">
-    <param name="use_sim_time" value="$(var with_ros2bag)"/>
+    <param if="$(var with_ros2bag)" name="use_sim_time" value="true"/>
+    <param unless="$(var with_ros2bag)" name="use_sim_time" value="$(var use_sim_time)"/>
     <remap from="/scan_1" to="$(var scan_1)"/>
     <remap from="/scan_2" to="$(var scan_2)"/>
     <remap from="/odom" to="$(var odom)"/>
   </node>
   <!-- occupancy_grid -->
   <node pkg="cartographer_ros" exec="cartographer_occupancy_grid_node" args="-resolution $(var resolution)    -publish_period_sec $(var publish_period_sec)">
-    <param name="use_sim_time" value="$(var with_ros2bag)"/>
+    <param if="$(var with_ros2bag)" name="use_sim_time" value="true"/>
+    <param unless="$(var with_ros2bag)" name="use_sim_time" value="$(var use_sim_time)"/>
   </node>
 </launch>

--- a/orange_slam/launch/cartographer.launch.xml
+++ b/orange_slam/launch/cartographer.launch.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="use_sim_time" default="true"/>
   <arg name="with_ros2bag" default="false"/>
   <arg name="scan_1" default="/velodyne_scan"/>
   <arg name="scan_2" default="/hokuyo_scan"/>
@@ -15,20 +14,15 @@
   <include file="$(find-pkg-share orange_bringup)/launch/rviz2.launch.xml">
     <arg name="config_file_path" value="$(var rviz_config_file_path)"/>
   </include>
-  <!-- robot_state_publisher -->
-  <node if="$(var with_ros2bag)" pkg="robot_state_publisher" exec="robot_state_publisher">
-    <param name="use_sim_time" value="$(var use_sim_time)"/>
-    <param name="robot_description" value="$(command 'xacro $(var xacro_file_path)')"/>
-  </node>
   <!-- cartographer_node -->
   <node pkg="cartographer_ros" exec="cartographer_node" args="-configuration_directory $(var slam_config_file_dir)    -configuration_basename $(var slam_config_file_name)">
-    <param name="use_sim_time" value="$(var use_sim_time)"/>
+    <param name="use_sim_time" value="$(var with_ros2bag)"/>
     <remap from="/scan_1" to="$(var scan_1)"/>
     <remap from="/scan_2" to="$(var scan_2)"/>
     <remap from="/odom" to="$(var odom)"/>
   </node>
   <!-- occupancy_grid -->
   <node pkg="cartographer_ros" exec="cartographer_occupancy_grid_node" args="-resolution $(var resolution)    -publish_period_sec $(var publish_period_sec)">
-    <param name="use_sim_time" value="$(var use_sim_time)"/>
+    <param name="use_sim_time" value="$(var with_ros2bag)"/>
   </node>
 </launch>

--- a/orange_slam/launch/slam_toolbox.launch.xml
+++ b/orange_slam/launch/slam_toolbox.launch.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="use_sim_time" default="true"/>
   <arg name="with_ros2bag" default="false"/>
   <arg name="online_slam_config_file_path" default="$(find-pkg-share orange_slam)/config/online_slam_toolbox_params.yaml"/>
   <arg name="offline_slam_config_file_path" default="$(find-pkg-share orange_slam)/config/offline_slam_toolbox_params.yaml"/>
@@ -12,11 +11,11 @@
   </include>
   <!-- slam_toolbox -->
   <node if="$(var with_ros2bag)" pkg="slam_toolbox" exec="sync_slam_toolbox_node">
-    <param name="use_sim_time" value="$(var use_sim_time)"/>
+    <param name="use_sim_time" value="$(var with_ros2bag)"/>
     <param from="$(var offline_slam_config_file_path)"/>
   </node>
   <node unless="$(var with_ros2bag)" pkg="slam_toolbox" exec="async_slam_toolbox_node">
-    <param name="use_sim_time" value="$(var use_sim_time)"/>
+    <param name="use_sim_time" value="$(var with_ros2bag)"/>
     <param from="$(var online_slam_config_file_path)"/>
   </node>
 </launch>

--- a/orange_slam/launch/slam_toolbox.launch.xml
+++ b/orange_slam/launch/slam_toolbox.launch.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="use_sim_time" default="false"/>
   <arg name="with_ros2bag" default="false"/>
   <arg name="online_slam_config_file_path" default="$(find-pkg-share orange_slam)/config/online_slam_toolbox_params.yaml"/>
   <arg name="offline_slam_config_file_path" default="$(find-pkg-share orange_slam)/config/offline_slam_toolbox_params.yaml"/>
@@ -11,11 +12,11 @@
   </include>
   <!-- slam_toolbox -->
   <node if="$(var with_ros2bag)" pkg="slam_toolbox" exec="sync_slam_toolbox_node">
-    <param name="use_sim_time" value="$(var with_ros2bag)"/>
+    <param name="use_sim_time" value="true"/>
     <param from="$(var offline_slam_config_file_path)"/>
   </node>
   <node unless="$(var with_ros2bag)" pkg="slam_toolbox" exec="async_slam_toolbox_node">
-    <param name="use_sim_time" value="$(var with_ros2bag)"/>
+    <param name="use_sim_time" value="$(var use_sim_time)"/>
     <param from="$(var online_slam_config_file_path)"/>
   </node>
 </launch>

--- a/orange_slam/launch/slam_toolbox.launch.xml
+++ b/orange_slam/launch/slam_toolbox.launch.xml
@@ -10,11 +10,6 @@
   <include file="$(find-pkg-share orange_bringup)/launch/rviz2.launch.xml">
     <arg name="config_file_path" value="$(var rviz_config_file_path)"/>
   </include>
-  <!-- robot_state_publisher -->
-  <node if="$(var with_ros2bag)" pkg="robot_state_publisher" exec="robot_state_publisher">
-    <param name="use_sim_time" value="$(var use_sim_time)"/>
-    <param name="robot_description" value="$(command 'xacro $(var xacro_file_path)')"/>
-  </node>
   <!-- slam_toolbox -->
   <node if="$(var with_ros2bag)" pkg="slam_toolbox" exec="sync_slam_toolbox_node">
     <param name="use_sim_time" value="$(var use_sim_time)"/>


### PR DESCRIPTION
## 概要

- ros2 bag用のlaunchファイルの作成。
- `use_sim_time`オプションのデフォルトの変更、及び足りていない箇所への追加。
- motor_driver_nodeの`publish_TF`がdefaultで`true`になっていた問題の修正。
- `cartographer.launch.xml`, `slam_toolbox.launch.xml`のrobot_state_publisherを削除。
- README.mdの更新。
- fix #51 

### なぜこのタスクを行うのか
> ros2 bag用のlaunchファイルの作成。
`use_sim_time`オプションのデフォルトの変更、及び足りていない箇所への追加。
`cartographer.launch.xml`, `slam_toolbox.launch.xml`のrobot_state_publisherを削除。

- この修正によってros2 bagに含むトピックは以下のみで地図作成(slam_toolbox, cartographer)が出来るようになります。
  - `/velodyne_points` : sensor_msgs/msg/PointCloud2
  - `/odom` : nav_msgs/msg/Odometry
  - `/imu` : sensor_msgs/msg/Imu
  - `/hokuyo_scan` : sensor_msgs/msg/LaserScan
___
> motor_driver_nodeの`publish_TF`がdefaultで`true`になっていた問題の修正。

- motor_driver_nodeがtfを投げると、robot_localizationの投げるtfと競合します。