### PR TITLE
fix_scale_angular

### DIFF
--- a/orange_teleop/config/dualsense.yaml
+++ b/orange_teleop/config/dualsense.yaml
@@ -8,9 +8,9 @@ teleop_twist_joy_node:
       x: 1.0 # [m/s] Maximum speed for Tsukuba Challenge
 
     axis_angular:
-      yaw: 3 # Right Stick Horizontal Movement
-    scale_angular:
       yaw: 0 # Left Stick Horizontal Movement
+    scale_angular:
+      yaw: 0.4 # [rad/s]
 
     enable_button: 6  # L2 Button
     enable_turbo_button: 1  # Circle Button


### PR DESCRIPTION
## 概要

- ROS2でDualSenseを利用するための, ボタン配置の割り当て修正. 

### なぜこのタスクを行うのか

- scale_angularの値が0になっており, ロボットが動けなくなっていたため. 

### やったこと

- scale_angularの値を0→0.4に変更した. 

### できるようになること

- DualSenseの利用. 