### PR TITLE
add_estop_ros

### DIFF
--- a/orange_bringup/launch/orange_robot.launch.xml
+++ b/orange_bringup/launch/orange_robot.launch.xml
@@ -94,6 +94,14 @@
     <arg name="imu_topic" value="imu"/>
     <arg name="frame_id" value="imu_link"/>
     <arg name="debug" value="$(var debug_imu)"/>
+  <!-- estop  -->
+  <include file="$(find-pkg-share estop_ros)/launch/estop_control.launch.xml">
+    <arg name="port" value="/dev/sensors/estop"/>
+    <arg name="time_out" value="500"/>
+    <arg name="baudrate" value="115200"/>
+    <arg name="serial_interval" value="0.01"/>
+    <arg name="input_topic" value="/cmd_vel/raw"/>
+    <arg name="output_topic" value="/cmd_vel/override"/>
   </include>
   <!-- pointcloud_to_laserscan -->
   <include file="$(find-pkg-share orange_sensor_tools)/launch/pointcloud_to_laserscan.launch.xml">

--- a/orange_bringup/launch/orange_robot.launch.xml
+++ b/orange_bringup/launch/orange_robot.launch.xml
@@ -10,7 +10,7 @@
   <arg name="debug_imu" default="false"/>
   <arg name="publish_TF" default="false"/>
   <arg name="publish_odom" default="true"/>
-  <arg name="twist_cmd_vel_topic" default="/cmd_vel_override"/>
+  <arg name="twist_cmd_vel_topic" default="/cmd_vel"/>
   <arg name="cmd_vel_topic" default="/vel/cmd_vel"/>
   <arg name="cmd_rpm_topic" default="/vel/cmd_rpm"/>
   <arg name="cmd_deg_topic" default="/pos/cmd_deg"/>
@@ -101,8 +101,7 @@
     <arg name="time_out" value="500"/>
     <arg name="baudrate" value="115200"/>
     <arg name="serial_interval" value="0.01"/>
-    <arg name="input_topic" value="/cmd_vel"/>
-    <arg name="output_topic" value="$(var twist_cmd_vel_topic)"/>
+    <remap from="/estop/state" to="$/estop"/>
   </include>
   <!-- pointcloud_to_laserscan -->
   <include file="$(find-pkg-share orange_sensor_tools)/launch/pointcloud_to_laserscan.launch.xml">

--- a/orange_bringup/launch/orange_robot.launch.xml
+++ b/orange_bringup/launch/orange_robot.launch.xml
@@ -96,13 +96,13 @@
     <arg name="debug" value="$(var debug_imu)"/>
   </include>
   <!-- estop  -->
-  <include file="$(find-pkg-share estop_ros)/launch/estop_control.launch.xml">
-    <arg name="port" value="/dev/sensors/estop"/>
-    <arg name="time_out" value="500"/>
-    <arg name="baudrate" value="115200"/>
-    <arg name="serial_interval" value="0.01"/>
-    <remap from="/estop/state" to="$/estop"/>
-  </include>
+  <node pkg="estop_ros" exec="cmd_vel_override_node" output="screen">
+    <param name="port" value="/dev/sensors/estop" />
+    <param name="baudrate" value="115200" />
+    <param name="time_out" value="500" />
+    <param name="serial_interval" value="0.01" />
+    <remap from="/estop/state" to="/estop"/>
+  </node>
   <!-- pointcloud_to_laserscan -->
   <include file="$(find-pkg-share orange_sensor_tools)/launch/pointcloud_to_laserscan.launch.xml">
     <arg name="cloud_in" value="$(var velodyne_points_topic)"/>

--- a/orange_bringup/launch/orange_robot.launch.xml
+++ b/orange_bringup/launch/orange_robot.launch.xml
@@ -94,14 +94,15 @@
     <arg name="imu_topic" value="imu"/>
     <arg name="frame_id" value="imu_link"/>
     <arg name="debug" value="$(var debug_imu)"/>
+  </include>
   <!-- estop  -->
   <include file="$(find-pkg-share estop_ros)/launch/estop_control.launch.xml">
     <arg name="port" value="/dev/sensors/estop"/>
     <arg name="time_out" value="500"/>
     <arg name="baudrate" value="115200"/>
     <arg name="serial_interval" value="0.01"/>
-    <arg name="input_topic" value="/cmd_vel/raw"/>
-    <arg name="output_topic" value="/cmd_vel/override"/>
+    <arg name="input_topic" value="/cmd_vel"/>
+    <arg name="output_topic" value="$(var twist_cmd_vsl_topic)"/>
   </include>
   <!-- pointcloud_to_laserscan -->
   <include file="$(find-pkg-share orange_sensor_tools)/launch/pointcloud_to_laserscan.launch.xml">

--- a/orange_bringup/launch/orange_robot.launch.xml
+++ b/orange_bringup/launch/orange_robot.launch.xml
@@ -10,7 +10,7 @@
   <arg name="debug_imu" default="false"/>
   <arg name="publish_TF" default="false"/>
   <arg name="publish_odom" default="true"/>
-  <arg name="twist_cmd_vel_topic" default="/cmd_vel"/>
+  <arg name="twist_cmd_vel_topic" default="/cmd_vel_override"/>
   <arg name="cmd_vel_topic" default="/vel/cmd_vel"/>
   <arg name="cmd_rpm_topic" default="/vel/cmd_rpm"/>
   <arg name="cmd_deg_topic" default="/pos/cmd_deg"/>
@@ -102,7 +102,7 @@
     <arg name="baudrate" value="115200"/>
     <arg name="serial_interval" value="0.01"/>
     <arg name="input_topic" value="/cmd_vel"/>
-    <arg name="output_topic" value="$(var twist_cmd_vsl_topic)"/>
+    <arg name="output_topic" value="$(var twist_cmd_vel_topic)"/>
   </include>
   <!-- pointcloud_to_laserscan -->
   <include file="$(find-pkg-share orange_sensor_tools)/launch/pointcloud_to_laserscan.launch.xml">

--- a/orange_bringup/launch/orange_robot.launch.xml
+++ b/orange_bringup/launch/orange_robot.launch.xml
@@ -97,10 +97,10 @@
   </include>
   <!-- estop  -->
   <node pkg="estop_ros" exec="cmd_vel_override_node" output="screen">
-    <param name="port" value="/dev/sensors/estop" />
-    <param name="baudrate" value="115200" />
-    <param name="time_out" value="500" />
-    <param name="serial_interval" value="0.01" />
+    <param name="port" value="/dev/sensors/estop"/>
+    <param name="baudrate" value="115200"/>
+    <param name="time_out" value="500"/>
+    <param name="serial_interval" value="0.01"/>
     <remap from="/estop/state" to="/estop"/>
   </node>
   <!-- pointcloud_to_laserscan -->

--- a/orange_bringup/orange_bringup/motor_driver_node.py
+++ b/orange_bringup/orange_bringup/motor_driver_node.py
@@ -123,7 +123,7 @@ class MotorDriverNode(Node):
             self.dist_cmd_callback,
             1,
         )
-        self.create_subscription(Bool, "/estop", self.estop_callback, 10)
+        self.create_subscription(Bool, "/estop", self.estop_callback, 1)
 
         # -----Initialize Control Mode-----
         self.control_mode = (

--- a/orange_ros2.rosinstall
+++ b/orange_ros2.rosinstall
@@ -6,3 +6,7 @@
     local-name: icm_20948
     uri: https://github.com/KBKN-Autonomous-Robotics-Lab/icm_20948.git
     version: humble-devel
+- git:
+    local-name: estop_ros
+    uri: https://github.com/KBKN-Autonomous-Robotics-Lab/estop_ros.git
+    version: humble-devel

--- a/orange_ros2.rosinstall
+++ b/orange_ros2.rosinstall
@@ -10,4 +10,3 @@
     local-name: estop_ros
     uri: https://github.com/KBKN-Autonomous-Robotics-Lab/estop_ros.git
     version: humble-devel
-    

--- a/orange_ros2.rosinstall
+++ b/orange_ros2.rosinstall
@@ -10,3 +10,4 @@
     local-name: estop_ros
     uri: https://github.com/KBKN-Autonomous-Robotics-Lab/estop_ros.git
     version: humble-devel
+    


### PR DESCRIPTION
## 概要

- 実機でestopを利用するためのestopパッケージの追加作業.

### なぜこのタスクを行うのか

- 実機でestopを利用するため.

### やったこと

- orange_ros2/orange_ros2.rosinstallとorange_ros2/orange_bringup/launch/orange_robot.launch.xml内への追記.

### できるようになること

- 実機でのestop利用. 

### その他
<!-- レビューアーに確認してもらいたいこと -->

- 実機で実際に利用できるのかはまだわかりません.
