### PR TITLE
add_waypoint_app_in_rosinstall

### DIFF
--- a/orange_ros2.rosinstall
+++ b/orange_ros2.rosinstall
@@ -10,3 +10,7 @@
     local-name: estop_ros
     uri: https://github.com/KBKN-Autonomous-Robotics-Lab/estop_ros.git
     version: humble-devel
+- git:
+    local-name: orange_navigation
+    uri: https://github.com/KBKN-Autonomous-Robotics-Lab/orange_navigation.git
+    version: humble-devel

--- a/orange_ros2.rosinstall
+++ b/orange_ros2.rosinstall
@@ -13,4 +13,4 @@
 - git:
     local-name: orange_navigation
     uri: https://github.com/KBKN-Autonomous-Robotics-Lab/orange_navigation.git
-    version: ros2_humble
+    version: waypoint_app-devel

--- a/orange_ros2.rosinstall
+++ b/orange_ros2.rosinstall
@@ -13,4 +13,4 @@
 - git:
     local-name: orange_navigation
     uri: https://github.com/KBKN-Autonomous-Robotics-Lab/orange_navigation.git
-    version: humble-devel
+    version: ros2_humble


### PR DESCRIPTION
## 概要

- waypoint編集アプリをROS2で利用するための作業. 

### なぜこのタスクを行うのか

- waypoint編集アプリをROS2実機で利用するため. 

### やったこと

- orange_ros2.rosinstallへのorange_navigationの追記. 

### できるようになること

- 実機でのwaypoint編集アプリの利用. 

### その他
<!-- レビューアーに確認してもらいたいこと -->

- Dockerfileへの追記も行うためそれと併せて確認していただけますと幸いです.
- 先にこっちでお願いします. 
