### PR TITLE
Feature/start from mid

### DIFF
--- a/orange_gazebo/launch/orange_hosei.launch.xml
+++ b/orange_gazebo/launch/orange_hosei.launch.xml
@@ -12,6 +12,9 @@
   <arg name="fusion_odom_topic" default="/fusion/odom"/>
   <arg name="world_file_path" default="$(find-pkg-share orange_gazebo)/worlds/orange_hosei.world"/>
   <arg name="xacro_file_path" default="$(find-pkg-share orange_description)/xacro/orange_robot.xacro"/>
+  <arg name="x" default="0.0"/>
+  <arg name="y" default="0.0"/>
+  <arg name="yaw" default="0.0"/>
   <!-- pointcloud_to_laserscan -->
   <include file="$(find-pkg-share orange_sensor_tools)/launch/pointcloud_to_laserscan.launch.xml">
     <arg name="use_sim_time" value="$(var use_sim_time)"/>
@@ -49,7 +52,8 @@
     <param name="robot_description" value="$(command 'xacro $(var xacro_file_path)')"/>
   </node>
   <!-- spawn_entity -->
-  <node pkg="gazebo_ros" exec="spawn_entity.py" args="-entity orange_robot -topic /robot_description">
+  <node pkg="gazebo_ros" exec="spawn_entity.py"
+        args="-entity orange_robot -topic /robot_description -x $(var x) -y $(var y) -Y $(var yaw)">
     <param name="use_sim_time" value="$(var use_sim_time)"/>
   </node>
 </launch>

--- a/orange_gazebo/launch/orange_hosei.launch.xml
+++ b/orange_gazebo/launch/orange_hosei.launch.xml
@@ -52,8 +52,7 @@
     <param name="robot_description" value="$(command 'xacro $(var xacro_file_path)')"/>
   </node>
   <!-- spawn_entity -->
-  <node pkg="gazebo_ros" exec="spawn_entity.py"
-        args="-entity orange_robot -topic /robot_description -x $(var x) -y $(var y) -Y $(var yaw)">
+  <node pkg="gazebo_ros" exec="spawn_entity.py" args="-entity orange_robot -topic /robot_description -x $(var x) -y $(var y) -Y $(var yaw)">
     <param name="use_sim_time" value="$(var use_sim_time)"/>
   </node>
 </launch>

--- a/orange_navigation/launch/multi_map_navigation.launch.xml
+++ b/orange_navigation/launch/multi_map_navigation.launch.xml
@@ -2,7 +2,7 @@
 <launch>
   <!-- Arguments -->
   <arg name="use_sim_time" default="false"/>
-  <arg name="multi_map_dir" default="$(find-pkg-share map_changer)/test"/>
+  <arg name="multi_map_dir" default="$(find-pkg-share kbkn_maps)/multi_map/hosei/m2/courtyard"/>
   <arg name="start_map_num" default="0"/>
   <arg name="map_file_path" default="$(var multi_map_dir)/map$(var start_map_num).yaml"/>
   <arg name="waypoints_file" default="$(var multi_map_dir)/waypoints.yaml"/>

--- a/orange_navigation/launch/multi_map_navigation.launch.xml
+++ b/orange_navigation/launch/multi_map_navigation.launch.xml
@@ -11,6 +11,7 @@
   <arg name="robot_frame" default="base_footprint"/>
   <arg name="min_dist_err" default="0.3"/>
   <arg name="min_yaw_err" default="0.3"/>
+  <arg name="from_middle" default="false"/>
   <arg name="tandem_scan" default="merged_scan"/>
   <arg name="use_angle" default="20.0"/>
   <arg name="danger_dist" default="2.0"/>
@@ -30,6 +31,7 @@
     <arg name="robot_frame" value="$(var robot_frame)"/>
     <arg name="min_dist_err" value="$(var min_dist_err)"/>
     <arg name="min_yaw_err" value="$(var min_yaw_err)"/>
+    <arg name="from_middle" value="$(var from_middle)"/>
     <arg name="tandem_scan" value="$(var tandem_scan)"/>
     <arg name="use_angle" value="$(var use_angle)"/>
     <arg name="danger_dist" value="$(var danger_dist)"/>

--- a/orange_navigation/launch/waypoint_navigation.launch.xml
+++ b/orange_navigation/launch/waypoint_navigation.launch.xml
@@ -10,6 +10,7 @@
   <arg name="robot_frame" default="base_footprint"/>
   <arg name="min_dist_err" default="0.3"/>
   <arg name="min_yaw_err" default="0.3"/>
+  <arg name="from_middle" default="false"/>
   <arg name="tandem_scan" default="merged_scan"/>
   <arg name="use_angle" default="20.0"/>
   <arg name="danger_dist" default="2.0"/>
@@ -29,6 +30,7 @@
     <arg name="robot_frame" value="$(var robot_frame)"/>
     <arg name="min_dist_err" value="$(var min_dist_err)"/>
     <arg name="min_yaw_err" value="$(var min_yaw_err)"/>
+    <arg name="from_middle" value="$(var from_middle)"/>
     <arg name="tandem_scan" value="$(var tandem_scan)"/>
     <arg name="use_angle" value="$(var use_angle)"/>
     <arg name="danger_dist" value="$(var danger_dist)"/>


### PR DESCRIPTION
## PR Type
<!--
Please select the type of changes you're introducing to the codebase:
-->
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Overview
- https://github.com/KBKN-Autonomous-Robotics-Lab/orange_navigation/pull/19 こちらで追加した、途中のウェイポイントからナビゲーションを始める機能を有効化する arg を launch ファイルに追加
- orange_hosei のシミュレーションで、ロボットの初期スポーン姿勢を指定できる arg を追加
<!--
Brief summary of the changes made in this PR.
-->

## Detail
- waypoint_navigation.launch.xml と multi_map_navigation.launch.xml に、from_middle という引数を追加しました。
- 機能についての詳細は、上記の orange_navigation の方の PR に記載してありますので、ご確認ください。
- 途中のウェイポイントから始めたいときは、以下のように true に指定して launch してください。
```
$ ros2 launch orange_ros2 waypoint_navigation.launch.xml from_middle:=true
```
- 機能を有効化するには、launch 後に rviz の 2D Pose Estimate でロボットの位置を指定する必要があります。
- シミュレーションでの検証時に欲しかったので、orange_hosei.launch.xml にロボットの初期姿勢を指定する引数を追加しました。
<!--
In-depth description of the changes, especially if the changes are significant or complex.
-->

## Test
- [x] シミュレーションでの検証
- [ ] 実環境での検証 
<!--
what was done to ensure it works.
Example:
- [ ] I have tested this change with gazebo
- [ ] I have tested this change with rosbag
-->

## Attention
- 実際使うときは、multi_map_navigation で地図の番号を指定することが多いと思います。地図の番号は、map_mergerで地図を結合したときの順番で、0から始まります。実環境でテストする際はこれも同時にテストしていただけると助かります。
- 例えば、2つめの地図（番号1）から始めたいときは、以下のように指定してください。
```
$ ros2 launch orange_navigation multi_map_navigation.launch.xml from_middle:=true start_map_num:=1
```
<!--
Any particular attention or caution the reviewers should have regarding the PR.
-->
