### PR TITLE
Fix/nav2 param navigation

### DIFF
--- a/orange_navigation/config/navigation2_params.yaml
+++ b/orange_navigation/config/navigation2_params.yaml
@@ -124,8 +124,8 @@ controller_server:
     general_goal_checker:
       stateful: True
       plugin: "nav2_controller::SimpleGoalChecker"
-      xy_goal_tolerance: 0.25
-      yaw_goal_tolerance: 0.50
+      xy_goal_tolerance: 0.10
+      yaw_goal_tolerance: 0.10
 
     FollowPath:
       plugin: "dwb_core::DWBLocalPlanner"
@@ -198,7 +198,7 @@ local_costmap:
       width: 8
       height: 8
       resolution: 0.05
-      footprint: "[ [0.40, 0.45], [0.40, -0.45], [-0.70, -0.45], [-0.70, 0.45] ]"
+      footprint: "[ [0.20, 0.33], [0.20, -0.33], [-0.65, -0.33], [-0.65, 0.33] ]"
       plugins: ["obstacle_layer", "inflation_layer"]
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"

--- a/orange_navigation/launch/multi_map_navigation.launch.xml
+++ b/orange_navigation/launch/multi_map_navigation.launch.xml
@@ -10,7 +10,7 @@
   <arg name="world_frame" default="map"/>
   <arg name="robot_frame" default="base_footprint"/>
   <arg name="min_dist_err" default="0.3"/>
-  <arg name="min_yaw_err" default="0.3"/>
+  <arg name="min_yaw_err" default="0.5"/>
   <arg name="from_middle" default="false"/>
   <arg name="tandem_scan" default="merged_scan"/>
   <arg name="use_angle" default="20.0"/>

--- a/orange_navigation/launch/waypoint_navigation.launch.xml
+++ b/orange_navigation/launch/waypoint_navigation.launch.xml
@@ -9,7 +9,7 @@
   <arg name="world_frame" default="map"/>
   <arg name="robot_frame" default="base_footprint"/>
   <arg name="min_dist_err" default="0.3"/>
-  <arg name="min_yaw_err" default="0.3"/>
+  <arg name="min_yaw_err" default="0.5"/>
   <arg name="from_middle" default="false"/>
   <arg name="tandem_scan" default="merged_scan"/>
   <arg name="use_angle" default="20.0"/>


### PR DESCRIPTION
## PR Type
<!--
Please select the type of changes you're introducing to the codebase:
-->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Overview
- stopするはずのwaypointで停止しない問題対策のNav2param調整と, 狭い道を通るためのロボットfootprint調整. 
<!--
Brief summary of the changes made in this PR.
-->

## Detail

1. tandemが終わる位置にstopのパラメータがtrueになっているwaypointがあるとstopせずに通過してしまう問題があり, その原因として, navigation2のゴール到達判定と, waypoint_navigationのゴール到達判定の相違にあると考えたため, Nav2param内の到達判定を厳しく, waypoint_navigation内の到達判定を緩くすることで対応しました. これにより, 基本的waypoint_navigationの判定をもとに次の動作をするようになっています. 
2. 下記PRで急な障害物を確実に避けるために余分に大きくしたfootprintが大きすぎることが原因で狭い道を通ることができないことがつくばチャレンジ走行中に発覚したため, 下記PR変更前のfootprintに戻しました. 
参考；https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2/pull/73#issue-1972242508

<!--
In-depth description of the changes, especially if the changes are significant or complex.
-->

## Test
- [x] つくばで動作確認済み. 
<!--
what was done to ensure it works.
Example:
- [ ] I have tested this change with gazebo
- [ ] I have tested this change with rosbag
-->

## Attention
- レビューの際にはお手数ですがdevel/tsukuba2023_Seniorに対して出しているPRの内容とのずれがないかも確認していただきたいです. お願いいたします. 
<!--
Any particular attention or caution the reviewers should have regarding the PR.
-->
