### PR TITLE
Fix/tsukuba navigation

### DIFF
--- a/orange_navigation/config/navigation2_params_from_left.yaml
+++ b/orange_navigation/config/navigation2_params_from_left.yaml
@@ -23,7 +23,7 @@ amcl:
     laser_min_range: -1.0
     laser_model_type: "likelihood_field"
     set_initial_pose: True
-    initial_pose: {x: 0.0, y: 2.0, z: 0.0, yaw: 0.0}
+    initial_pose: {x: 0.0, y: 4.2, z: 0.0, yaw: 0.0}
     max_beams: 300
     max_particles: 1500
     min_particles: 500
@@ -124,8 +124,8 @@ controller_server:
     general_goal_checker:
       stateful: True
       plugin: "nav2_controller::SimpleGoalChecker"
-      xy_goal_tolerance: 0.25
-      yaw_goal_tolerance: 0.50
+      xy_goal_tolerance: 0.10 #0.25
+      yaw_goal_tolerance: 0.10 #0.50
 
     FollowPath:
       plugin: "dwb_core::DWBLocalPlanner"
@@ -198,7 +198,7 @@ local_costmap:
       width: 8
       height: 8
       resolution: 0.05
-      footprint: "[ [0.40, 0.45], [0.40, -0.45], [-0.70, -0.45], [-0.70, 0.45] ]"
+      footprint: "[ [0.20, 0.33], [0.20, -0.33], [-0.65, -0.33], [-0.65, 0.33] ]"
       plugins: ["obstacle_layer", "inflation_layer"]
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"

--- a/orange_navigation/config/navigation2_params_from_left.yaml
+++ b/orange_navigation/config/navigation2_params_from_left.yaml
@@ -124,8 +124,8 @@ controller_server:
     general_goal_checker:
       stateful: True
       plugin: "nav2_controller::SimpleGoalChecker"
-      xy_goal_tolerance: 0.10 #0.25
-      yaw_goal_tolerance: 0.10 #0.50
+      xy_goal_tolerance: 0.10
+      yaw_goal_tolerance: 0.10
 
     FollowPath:
       plugin: "dwb_core::DWBLocalPlanner"

--- a/orange_navigation/config/navigation2_params_from_right.yaml
+++ b/orange_navigation/config/navigation2_params_from_right.yaml
@@ -258,7 +258,7 @@ global_costmap:
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
         cost_scaling_factor: 2.0
-        inflation_radius: 1.5
+        inflation_radius: 3.0
       always_send_full_costmap: True
   global_costmap_client:
     ros__parameters:

--- a/orange_navigation/config/navigation2_params_from_right.yaml
+++ b/orange_navigation/config/navigation2_params_from_right.yaml
@@ -124,8 +124,8 @@ controller_server:
     general_goal_checker:
       stateful: True
       plugin: "nav2_controller::SimpleGoalChecker"
-      xy_goal_tolerance: 0.25
-      yaw_goal_tolerance: 0.50
+      xy_goal_tolerance: 0.10
+      yaw_goal_tolerance: 0.10
 
     FollowPath:
       plugin: "dwb_core::DWBLocalPlanner"
@@ -198,7 +198,7 @@ local_costmap:
       width: 8
       height: 8
       resolution: 0.05
-      footprint: "[ [0.40, 0.45], [0.40, -0.45], [-0.70, -0.45], [-0.70, 0.45] ]"
+      footprint: "[ [0.20, 0.33], [0.20, -0.33], [-0.65, -0.33], [-0.65, 0.33] ]"
       plugins: ["obstacle_layer", "inflation_layer"]
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
@@ -258,7 +258,7 @@ global_costmap:
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
         cost_scaling_factor: 2.0
-        inflation_radius: 3.0
+        inflation_radius: 1.5
       always_send_full_costmap: True
   global_costmap_client:
     ros__parameters:

--- a/orange_navigation/launch/multi_map_navigation.launch.xml
+++ b/orange_navigation/launch/multi_map_navigation.launch.xml
@@ -11,7 +11,7 @@
   <arg name="world_frame" default="map"/>
   <arg name="robot_frame" default="base_footprint"/>
   <arg name="min_dist_err" default="0.3"/>
-  <arg name="min_yaw_err" default="0.3"/>
+  <arg name="min_yaw_err" default="0.5"/>
   <arg name="from_middle" default="false"/>
   <arg name="tandem_scan" default="merged_scan"/>
   <arg name="use_angle" default="20.0"/>

--- a/orange_navigation/launch/waypoint_navigation.launch.xml
+++ b/orange_navigation/launch/waypoint_navigation.launch.xml
@@ -5,7 +5,7 @@
   <arg name="kbkn_maps_path" default="hosei/m2/courtyard_Senior.yaml"/>
   <arg name="map_file_path" default="$(find-pkg-share kbkn_maps)/maps/$(var kbkn_maps_path)"/>
   <arg name="waypoints_file" default="$(find-pkg-share kbkn_maps)/waypoints/$(var kbkn_maps_path)"/>
-  <arg name="config_file_path" default="$(find-pkg-share orange_navigation)/config/navigation2_params.yaml"/>
+  <arg name="config_file_path" default="$(find-pkg-share orange_navigation)/config/navigation2_params_from_left.yaml"/>
   <arg name="world_frame" default="map"/>
   <arg name="robot_frame" default="base_footprint"/>
   <arg name="min_dist_err" default="0.3"/>

--- a/orange_navigation/launch/waypoint_navigation.launch.xml
+++ b/orange_navigation/launch/waypoint_navigation.launch.xml
@@ -2,14 +2,14 @@
 <launch>
   <!-- Arguments -->
   <arg name="use_sim_time" default="false"/>
-  <arg name="kbkn_maps_path" default="hosei/m2/courtyard_Senior.yaml"/>
+  <arg name="kbkn_maps_path" default="tsukuba/m2/confirmation_run_Senior.yaml"/>
   <arg name="map_file_path" default="$(find-pkg-share kbkn_maps)/maps/$(var kbkn_maps_path)"/>
   <arg name="waypoints_file" default="$(find-pkg-share kbkn_maps)/waypoints/$(var kbkn_maps_path)"/>
   <arg name="config_file_path" default="$(find-pkg-share orange_navigation)/config/navigation2_params_from_left.yaml"/>
   <arg name="world_frame" default="map"/>
   <arg name="robot_frame" default="base_footprint"/>
   <arg name="min_dist_err" default="0.3"/>
-  <arg name="min_yaw_err" default="0.3"/>
+  <arg name="min_yaw_err" default="0.5"/>
   <arg name="from_middle" default="false"/>
   <arg name="tandem_scan" default="merged_scan"/>
   <arg name="use_angle" default="20.0"/>


### PR DESCRIPTION
## PR Type
<!--
Please select the type of changes you're introducing to the codebase:
-->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Overview
- つくちゃれ2023左側スタート用ファイルの初期位置調整, ロボットのfootprint調整, stopするはずのwaypointで停止しない問題対策のNav2param調整. 
<!--
Brief summary of the changes made in this PR.
-->

## Detail

1. つくばチャレンジ2023で左側スタートの際のロボットの初期位置を変更しました. 走行位置のスタート位置のタイルが1枚60cmで7枚分離れていたため, 4.2mずらしました. 
2. 下記PRで急な障害物を確実に避けるために余分に大きくしたfootprintが大きすぎることが原因で狭い道を通ることができないことがつくばチャレンジ走行中に発覚したため, 下記PR変更前のfootprintに戻しました.
参考；https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2/pull/73#issue-1972242508
3. tandemが終わる位置にstopのパラメータがtrueになっているwaypointがあるとstopせずに通過してしまう問題があり, その原因として, navigation2のゴール到達判定と, waypoint_navigationのゴール到達判定の相違にあると考えたため, Nav2param内の到達判定を厳しく, waypoint_navigation内の到達判定を緩くすることで対応しました. これにより, 基本的waypoint_navigationの判定をもとに次の動作をするようになっています.

<!--
In-depth description of the changes, especially if the changes are significant or complex.
-->

## Test
- [x] つくばチャレンジ動作確認済み.  
<!--
what was done to ensure it works.
Example:
- [ ] I have tested this change with gazebo
- [ ] I have tested this change with rosbag
-->

## Attention
- つくちゃれ左側スタート用に初期位置を変えた点と, launch内で指定する走行コースがつくばようになっている以外は下記PRと同様の内容になっているはずです. 
参考；https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2/pull/82#issue-2001376561
<!--
Any particular attention or caution the reviewers should have regarding the PR.
-->
